### PR TITLE
Feature/unified move support

### DIFF
--- a/build/cmake/async_basics/CMakeLists.txt
+++ b/build/cmake/async_basics/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/service_base.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/sp_singleton.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal_service.hpp"
     "${CPP_HEADERS_DIR}/ma/tutorial/async_interface.hpp"

--- a/build/cmake/async_basics2/CMakeLists.txt
+++ b/build/cmake/async_basics2/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/service_base.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/sp_singleton.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal_service.hpp"
     "${CPP_HEADERS_DIR}/ma/tutorial2/async_implementation.hpp"

--- a/build/cmake/echo_server/CMakeLists.txt
+++ b/build/cmake/echo_server/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/sp_singleton.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/tuple.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal_service.hpp"
     "${CPP_HEADERS_DIR}/ma/bind_handler.hpp"

--- a/build/cmake/handler_storage_test/CMakeLists.txt
+++ b/build/cmake/handler_storage_test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/memory.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/service_base.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/bind_handler.hpp"
     "${CPP_HEADERS_DIR}/ma/config.hpp"
     "${CPP_HEADERS_DIR}/ma/console_close_guard.hpp"

--- a/build/cmake/nmea_client/CMakeLists.txt
+++ b/build/cmake/nmea_client/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/sp_singleton.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/tuple.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal_service.hpp"
     "${CPP_HEADERS_DIR}/ma/nmea/cyclic_read_session_fwd.hpp"

--- a/build/cmake/qt_echo_server/CMakeLists.txt
+++ b/build/cmake/qt_echo_server/CMakeLists.txt
@@ -93,6 +93,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/service_base.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/tuple.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/bind_handler.hpp"
     "${CPP_HEADERS_DIR}/ma/config.hpp"
     "${CPP_HEADERS_DIR}/ma/context_alloc_handler.hpp"

--- a/build/cmake/windows_console_signal_test/CMakeLists.txt
+++ b/build/cmake/windows_console_signal_test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CPP_HEADERS
     "${CPP_HEADERS_DIR}/ma/detail/service_base.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/sp_singleton.hpp"
     "${CPP_HEADERS_DIR}/ma/detail/thread.hpp"
+    "${CPP_HEADERS_DIR}/ma/detail/utility.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal.hpp"
     "${CPP_HEADERS_DIR}/ma/windows/console_signal_service.hpp"
     "${CPP_HEADERS_DIR}/ma/bind_handler.hpp"

--- a/include/ma/config.hpp
+++ b/include/ma/config.hpp
@@ -58,9 +58,9 @@
 #endif
 
 #if defined(MA_HAS_RVALUE_REFS)
-#define MA_RVALUE_CAST(v) (::std::move(v))
+#define MA_FWD_REF &&
 #else
-#define MA_RVALUE_CAST(v) (v)
+#define MA_FWD_REF const &
 #endif
 
 //todo: add support for other compilers (than MSVC, GCC, Clang)

--- a/include/ma/context_alloc_handler.hpp
+++ b/include/ma/context_alloc_handler.hpp
@@ -380,32 +380,32 @@ public:
 
   void operator()()
   {
-    handler_(static_cast<const Context&>(context_));
+    handler_(context_);
   }
 
   template <typename Arg1>
   void operator()(const Arg1& arg1)
   {
-    handler_(static_cast<const Context&>(context_), arg1);
+    handler_(context_, arg1);
   }
 
   template <typename Arg1, typename Arg2>
   void operator()(const Arg1& arg1, const Arg2& arg2)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2);
+    handler_(context_, arg1, arg2);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3);
+    handler_(context_, arg1, arg2, arg3);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
       const Arg4& arg4)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4);
+    handler_(context_, arg1, arg2, arg3, arg4);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
@@ -413,8 +413,7 @@ public:
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
       const Arg4& arg4, const Arg5& arg5)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4,
-        arg5);
+    handler_(context_, arg1, arg2, arg3, arg4, arg5);
   }
 
   void operator()() const

--- a/include/ma/context_wrapped_handler.hpp
+++ b/include/ma/context_wrapped_handler.hpp
@@ -367,32 +367,32 @@ public:
 
   void operator()()
   {
-    handler_(static_cast<const Context&>(context_));
+    handler_(context_);
   }
 
   template <typename Arg1>
   void operator()(const Arg1& arg1)
   {
-    handler_(static_cast<const Context&>(context_), arg1);
+    handler_(context_, arg1);
   }
 
   template <typename Arg1, typename Arg2>
   void operator()(const Arg1& arg1, const Arg2& arg2)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2);
+    handler_(context_, arg1, arg2);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3);
+    handler_(context_, arg1, arg2, arg3);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
       const Arg4& arg4)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4);
+    handler_(context_, arg1, arg2, arg3, arg4);
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
@@ -400,8 +400,7 @@ public:
   void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
       const Arg4& arg4, const Arg5& arg5)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4,
-        arg5);
+    handler_(context_, arg1, arg2, arg3, arg4, arg5);
   }
 
   void operator()() const

--- a/include/ma/detail/utility.hpp
+++ b/include/ma/detail/utility.hpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2010-2015 Marat Abrarov (abrarov@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MA_DETAIL_UTILITY_HPP
+#define MA_DETAIL_UTILITY_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include <ma/config.hpp>
+
+#if defined(MA_HAS_RVALUE_REFS)
+#include <utility>
+#endif
+
+namespace ma {
+namespace detail {
+
+#if defined(MA_HAS_RVALUE_REFS)
+
+using std::move;
+
+#else
+
+/// Dummy for std::move
+template <typename T>
+T& move(T& t) 
+{ 
+  return t;
+}
+
+#endif // defined(MA_HAS_RVALUE_REFS)
+
+} // namespace detail
+} // namespace ma
+
+#endif // MA_DETAIL_UTILITY_HPP

--- a/include/ma/detail/utility.hpp
+++ b/include/ma/detail/utility.hpp
@@ -24,13 +24,35 @@ namespace detail {
 #if defined(MA_HAS_RVALUE_REFS)
 
 using std::move;
+using std::forward;
 
-#else
+#else // defined(MA_HAS_RVALUE_REFS)
 
 /// Dummy for std::move
 template <typename T>
 T& move(T& t) 
 { 
+  return t;
+}
+
+/// Dummy for std::move
+template <typename T>
+const T& move(const T& t)
+{
+  return t;
+}
+
+/// Dummy for std::forward
+template <typename T>
+T& forward(T& t)
+{
+  return t;
+}
+
+/// Dummy for std::forward
+template <typename T>
+const T& forward(const T& t)
+{
   return t;
 }
 

--- a/include/ma/handler_storage_service.hpp
+++ b/include/ma/handler_storage_service.hpp
@@ -26,10 +26,7 @@
 #include <ma/detail/handler_ptr.hpp>
 #include <ma/detail/service_base.hpp>
 #include <ma/detail/intrusive_list.hpp>
-
-#if defined(MA_HAS_RVALUE_REFS)
-#include <utility>
-#endif // defined(MA_HAS_RVALUE_REFS)
+#include <ma/detail/utility.hpp>
 
 namespace ma {
 
@@ -628,7 +625,7 @@ void handler_storage_service::handler_wrapper<Handler, Arg, Target>::do_destroy(
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used
   // for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
@@ -649,19 +646,19 @@ void handler_storage_service::handler_wrapper<Handler, Arg, Target>::do_post(
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
   // Make copies of other data placed at wrapper object
   // These copies will be used after the wrapper object destruction
   // and deallocation of its memory
-  boost::asio::io_service::work work(MA_RVALUE_CAST(this_ptr->work_));
+  boost::asio::io_service::work work(detail::move(this_ptr->work_));
   // Destroy wrapper object and deallocate its memory
   // through the local copy of handler
   ptr.reset();
   // Post the copy of handler's local copy to io_service
   boost::asio::io_service& io_service = work.get_io_service();
-  io_service.post(bind_handler(MA_RVALUE_CAST(handler), arg));
+  io_service.post(bind_handler(detail::move(handler), arg));
 }
 
 template <typename Handler, typename Arg, typename Target>
@@ -777,7 +774,7 @@ void handler_storage_service::handler_wrapper<Handler, void, Target>::
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used
   // for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
@@ -798,19 +795,19 @@ void handler_storage_service::handler_wrapper<Handler, void, Target>::do_post(
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
   // Make copies of other data placed at wrapper object
   // These copies will be used after the wrapper object destruction
   // and deallocation of its memory
-  boost::asio::io_service::work work(MA_RVALUE_CAST(this_ptr->work_));
+  boost::asio::io_service::work work(detail::move(this_ptr->work_));
   // Destroy wrapper object and deallocate its memory
   // through the local copy of handler
   ptr.reset();
   // Post the copy of handler's local copy to io_service
   boost::asio::io_service& io_service = work.get_io_service();
-  io_service.post(MA_RVALUE_CAST(handler));
+  io_service.post(detail::move(handler));
 }
 
 template <typename Handler, typename Target>
@@ -923,7 +920,7 @@ void handler_storage_service::store(implementation_type& impl, Handler handler)
   // Create wrapped handler at allocated memory and
   // move ownership of allocated memory to ptr
   detail::handler_ptr<alloc_traits> ptr(raw_ptr,
-      detail::ref(this->get_io_service()), MA_RVALUE_CAST(handler));
+      detail::ref(this->get_io_service()), detail::move(handler));
   // Copy current handler
   stored_base* old_handler = impl.handler_;
   // Move ownership of already created wrapped handler

--- a/include/ma/windows/console_signal_service.hpp
+++ b/include/ma/windows/console_signal_service.hpp
@@ -28,10 +28,7 @@
 #include <ma/detail/handler_ptr.hpp>
 #include <ma/detail/service_base.hpp>
 #include <ma/detail/intrusive_list.hpp>
-
-#if defined(MA_HAS_RVALUE_REFS)
-#include <utility>
-#endif // defined(MA_HAS_RVALUE_REFS)
+#include <ma/detail/utility.hpp>
 
 namespace ma {
 namespace windows {
@@ -243,16 +240,15 @@ void console_signal_service::async_wait(
   lock_guard lock(mutex_);
   if (shutdown_)
   {
-    get_io_service().post(
-        bind_handler(MA_RVALUE_CAST(handler), 
-            boost::asio::error::operation_aborted));
+    get_io_service().post(bind_handler(detail::move(handler),
+        boost::asio::error::operation_aborted));
     return;
   }
   if (queued_signals_)
   {
     --queued_signals_;
-    get_io_service().post(
-        bind_handler(MA_RVALUE_CAST(handler), boost::system::error_code()));
+    get_io_service().post(bind_handler(detail::move(handler), 
+        boost::system::error_code()));
     return;
   }
 
@@ -261,7 +257,7 @@ void console_signal_service::async_wait(
 
   detail::raw_handler_ptr<alloc_traits> raw_ptr(handler);
   detail::handler_ptr<alloc_traits> ptr(raw_ptr,
-      detail::ref(this->get_io_service()), MA_RVALUE_CAST(handler));
+      detail::ref(this->get_io_service()), detail::move(handler));
 
   // Add handler to the list of waiting handlers.
   impl.handlers_.push_front(*ptr.get());
@@ -361,7 +357,7 @@ void console_signal_service::handler_wrapper<Handler>::do_destroy(
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used
   // for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
@@ -382,19 +378,19 @@ void console_signal_service::handler_wrapper<Handler>::do_post(
   detail::handler_ptr<alloc_traits> ptr(this_ptr->handler_, this_ptr);
   // Make a local copy of handler stored at wrapper object
   // This local copy will be used for wrapper's memory deallocation later
-  Handler handler(MA_RVALUE_CAST(this_ptr->handler_));
+  Handler handler(detail::move(this_ptr->handler_));
   // Change the handler which will be used for wrapper's memory deallocation
   ptr.set_alloc_context(handler);
   // Make copies of other data placed at wrapper object
   // These copies will be used after the wrapper object destruction
   // and deallocation of its memory
-  boost::asio::io_service::work work(MA_RVALUE_CAST(this_ptr->work_));
+  boost::asio::io_service::work work(detail::move(this_ptr->work_));
   // Destroy wrapper object and deallocate its memory
   // through the local copy of handler
   ptr.reset();
   // Post the copy of handler's local copy to io_service
   boost::asio::io_service& io_service = work.get_io_service();
-  io_service.post(ma::bind_handler(MA_RVALUE_CAST(handler), error));
+  io_service.post(ma::bind_handler(detail::move(handler), error));
 }
 
 } // namespace windows

--- a/src/handler_storage_test/main.cpp
+++ b/src/handler_storage_test/main.cpp
@@ -130,7 +130,7 @@ public:
 private:
   typedef boost::optional<boost::asio::io_service::work> optional_io_work;
 
-  optional_io_work    work_guard_;
+  optional_io_work work_guard_;
   ma::thread_group threads_;
 }; // class io_service_pool
 

--- a/src/ma/echo/server/session.cpp
+++ b/src/ma/echo/server/session.cpp
@@ -134,8 +134,8 @@ session::session(boost::asio::io_service& io_service,
   , socket_send_buffer_size_(config.socket_send_buffer_size)
   , no_delay_(config.no_delay)
   , inactivity_timeout_(to_optional_duration(config.inactivity_timeout))
-  , ext_state_(ext_state::ready)
-  , int_state_(int_state::work)
+  , extern_state_(extern_state::ready)
+  , intern_state_(intern_state::work)
   , read_state_(read_state::wait)
   , write_state_(write_state::wait)
   , timer_state_(timer_state::ready)
@@ -155,11 +155,11 @@ session::session(boost::asio::io_service& io_service,
 void session::reset()
 {
   // Reset state
-  ext_state_   = ext_state::ready;
-  int_state_   = int_state::work;
-  read_state_  = read_state::wait;
-  write_state_ = write_state::wait;
-  timer_state_ = timer_state::ready;
+  extern_state_ = extern_state::ready;
+  intern_state_ = intern_state::work;
+  read_state_   = read_state::wait;
+  write_state_  = write_state::wait;
+  timer_state_  = timer_state::ready;
 
   timer_wait_cancelled_ = false;
   timer_turned_         = false;
@@ -177,7 +177,7 @@ void session::reset()
 boost::system::error_code session::do_start_extern_start()
 {
   // Check external state consistency
-  if (ext_state::ready != ext_state_)
+  if (extern_state::ready != extern_state_)
   {
     return server::error::invalid_state;
   }
@@ -187,17 +187,17 @@ boost::system::error_code session::do_start_extern_start()
   {
     close_socket();
     // Switch states as SM suppose...
-    ext_state_   = ext_state::stopped;
-    int_state_   = int_state::stopped;
-    read_state_  = read_state::stopped;
-    write_state_ = write_state::stopped;
-    timer_state_ = timer_state::stopped;
+    extern_state_ = extern_state::stopped;
+    intern_state_ = intern_state::stopped;
+    read_state_   = read_state::stopped;
+    write_state_  = write_state::stopped;
+    timer_state_  = timer_state::stopped;
     // ... and notify start handler about error
     return error;
   }
 
   // Internal states have right values already
-  ext_state_ = ext_state::work;
+  extern_state_ = extern_state::work;
   continue_work();
 
   // Notify start handler about success
@@ -207,25 +207,25 @@ boost::system::error_code session::do_start_extern_start()
 session::optional_error_code session::do_start_extern_stop()
 {
   // Check external state consistency
-  if ((ext_state::stopped == ext_state_)
-      || (ext_state::stop == ext_state_))
+  if ((extern_state::stopped == extern_state_)
+      || (extern_state::stop == extern_state_))
   {
     return boost::system::error_code(server::error::invalid_state);
   }
 
   // Switch external SM
-  ext_state_ = ext_state::stop;
+  extern_state_ = extern_state::stop;
   complete_extern_wait(server::error::operation_aborted);
 
-  if (int_state::work == int_state_)
+  if (intern_state::work == intern_state_)
   {
     start_shutdown(server::error::operation_aborted, false);
   }
 
-  // int_state_ can be changed by start_active_shutdown
-  if (int_state::stopped == int_state_)
+  // intern_state_ can be changed by start_active_shutdown
+  if (intern_state::stopped == intern_state_)
   {
-    ext_state_ = ext_state::stopped;
+    extern_state_ = extern_state::stopped;
     // Notify stop handler about success
     return boost::system::error_code();
   }
@@ -237,13 +237,13 @@ session::optional_error_code session::do_start_extern_stop()
 session::optional_error_code session::do_start_extern_wait()
 {
   // Check external state consistency
-  if ((ext_state::work != ext_state_)
+  if ((extern_state::work != extern_state_)
       || extern_wait_handler_.has_target())
   {
     return boost::system::error_code(server::error::invalid_state);
   }
 
-  if (int_state::work != int_state_)
+  if (intern_state::work != intern_state_)
   {
     // Notify wait handler about the happened stop
     return extern_wait_error_;
@@ -284,17 +284,17 @@ void session::handle_read(const boost::system::error_code& error,
 
   // Split handler based on current internal state
   // that might change during read operation
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_read_at_work(error, bytes_transferred);
     break;
 
-  case int_state::shutdown:
+  case intern_state::shutdown:
     handle_read_at_shutdown(error, bytes_transferred);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_read_at_stop(error, bytes_transferred);
     break;
 
@@ -312,17 +312,17 @@ void session::handle_write(const boost::system::error_code& error,
 
   // Split handler based on current internal state
   // that might change during write operation
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_write_at_work(error, bytes_transferred);
     break;
 
-  case int_state::shutdown:
+  case intern_state::shutdown:
     handle_write_at_shutdown(error, bytes_transferred);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_write_at_stop(error, bytes_transferred);
     break;
 
@@ -339,14 +339,14 @@ void session::handle_timer(const boost::system::error_code& error)
 
   // Split handler based on current internal state
   // that might change during timer wait operation
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
-  case int_state::shutdown:
+  case intern_state::work:
+  case intern_state::shutdown:
     handle_timer_at_work(error);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_timer_at_stop(error);
     break;
 
@@ -363,7 +363,7 @@ void session::handle_timer(const boost::system::error_code& error)
 void session::handle_read_at_work(const boost::system::error_code& error,
     std::size_t bytes_transferred)
 {
-  BOOST_ASSERT_MSG(int_state::work == int_state_,
+  BOOST_ASSERT_MSG(intern_state::work == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::in_progress == read_state_,
@@ -408,7 +408,7 @@ void session::handle_read_at_work(const boost::system::error_code& error,
 void session::handle_read_at_shutdown(const boost::system::error_code& error,
     std::size_t bytes_transferred)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::in_progress == read_state_,
@@ -448,7 +448,7 @@ void session::handle_read_at_shutdown(const boost::system::error_code& error,
 void session::handle_read_at_stop(const boost::system::error_code& /*error*/,
     std::size_t /*bytes_transferred*/)
 {
-  BOOST_ASSERT_MSG(int_state::stop == int_state_,
+  BOOST_ASSERT_MSG(intern_state::stop == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::in_progress == read_state_,
@@ -462,7 +462,7 @@ void session::handle_read_at_stop(const boost::system::error_code& /*error*/,
 void session::handle_write_at_work(const boost::system::error_code& error,
     std::size_t bytes_transferred)
 {
-  BOOST_ASSERT_MSG(int_state::work == int_state_,
+  BOOST_ASSERT_MSG(intern_state::work == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(write_state::in_progress == write_state_,
@@ -495,7 +495,7 @@ void session::handle_write_at_work(const boost::system::error_code& error,
 void session::handle_write_at_shutdown(const boost::system::error_code& error,
     std::size_t bytes_transferred)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(write_state::in_progress == write_state_,
@@ -528,7 +528,7 @@ void session::handle_write_at_shutdown(const boost::system::error_code& error,
 void session::handle_write_at_stop(const boost::system::error_code& /*error*/,
     std::size_t /*bytes_transferred*/)
 {
-  BOOST_ASSERT_MSG(int_state::stop == int_state_,
+  BOOST_ASSERT_MSG(intern_state::stop == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(write_state::in_progress == write_state_,
@@ -541,8 +541,8 @@ void session::handle_write_at_stop(const boost::system::error_code& /*error*/,
 
 void session::handle_timer_at_work(const boost::system::error_code& error)
 {
-  BOOST_ASSERT_MSG((int_state::work == int_state_)
-      || (int_state::shutdown == int_state_),
+  BOOST_ASSERT_MSG((intern_state::work == intern_state_)
+      || (intern_state::shutdown == intern_state_),
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(timer_state::in_progress == timer_state_,
@@ -576,7 +576,7 @@ void session::handle_timer_at_work(const boost::system::error_code& error)
 
 void session::handle_timer_at_stop(const boost::system::error_code& /*error*/)
 {
-  BOOST_ASSERT_MSG(int_state::stop == int_state_,
+  BOOST_ASSERT_MSG(intern_state::stop == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(timer_state::in_progress == timer_state_,
@@ -589,7 +589,7 @@ void session::handle_timer_at_stop(const boost::system::error_code& /*error*/)
 
 void session::continue_work()
 {
-  BOOST_ASSERT_MSG(int_state::work == int_state_,
+  BOOST_ASSERT_MSG(intern_state::work == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(write_state::stopped != write_state_,
@@ -626,7 +626,7 @@ void session::continue_work()
 
 void session::continue_timer_wait()
 {
-  BOOST_ASSERT_MSG(int_state::stopped != int_state_,
+  BOOST_ASSERT_MSG(intern_state::stopped != intern_state_,
       "Invalid internal state");
 
   if (inactivity_timeout_)
@@ -659,7 +659,7 @@ void session::continue_timer_wait()
 
 void session::continue_shutdown(bool need_timer_restart)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   // Split control flow based on current state of read activity to simplify
@@ -685,7 +685,7 @@ void session::continue_shutdown(bool need_timer_restart)
 
 void session::continue_shutdown_at_read_wait(bool need_timer_restart)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::wait == read_state_,
@@ -733,7 +733,7 @@ void session::continue_shutdown_at_read_wait(bool need_timer_restart)
 
 void session::continue_shutdown_at_read_in_progress(bool need_timer_restart)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::in_progress == read_state_,
@@ -760,7 +760,7 @@ void session::continue_shutdown_at_read_in_progress(bool need_timer_restart)
 
 void session::continue_shutdown_at_read_stopped(bool need_timer_restart)
 {
-  BOOST_ASSERT_MSG(int_state::shutdown == int_state_,
+  BOOST_ASSERT_MSG(intern_state::shutdown == intern_state_,
       "Invalid internal state");
 
   BOOST_ASSERT_MSG(read_state::stopped == read_state_,
@@ -802,7 +802,7 @@ void session::continue_shutdown_at_read_stopped(bool need_timer_restart)
 
 void session::continue_stop()
 {
-  BOOST_ASSERT_MSG(int_state::stop == int_state_,
+  BOOST_ASSERT_MSG(intern_state::stop == intern_state_,
       "Invalid internal state");
 
   if (!pending_operations_)
@@ -817,11 +817,11 @@ void session::continue_stop()
         "Invalid timer state");
 
     // Internal general stop completed
-    int_state_ = int_state::stopped;
+    intern_state_ = intern_state::stopped;
 
-    if (ext_state::stop == ext_state_)
+    if (extern_state::stop == extern_state_)
     {
-      ext_state_ = ext_state::stopped;
+      extern_state_ = extern_state::stopped;
       complete_extern_stop(boost::system::error_code());
     }
   }
@@ -830,14 +830,14 @@ void session::continue_stop()
 void session::start_shutdown(const boost::system::error_code& error,
     bool need_timer_restart)
 {
-  BOOST_ASSERT_MSG(int_state::work == int_state_,
+  BOOST_ASSERT_MSG(intern_state::work == intern_state_,
       "Invalid internal state");
 
   // Siwtch general internal SM
-  int_state_ = int_state::shutdown;
+  intern_state_ = intern_state::shutdown;
 
   // Notify external wait handler if need
-  if (ext_state::work == ext_state_)
+  if (extern_state::work == extern_state_)
   {
     complete_extern_wait(error);
   }
@@ -847,12 +847,12 @@ void session::start_shutdown(const boost::system::error_code& error,
 
 void session::start_stop(boost::system::error_code error)
 {
-  BOOST_ASSERT_MSG((int_state::work == int_state_)
-      || (int_state::shutdown == int_state_),
+  BOOST_ASSERT_MSG((intern_state::work == intern_state_)
+      || (intern_state::shutdown == intern_state_),
       "Invalid internal state");
 
   // Siwtch general internal SM
-  int_state_ = int_state::stop;
+  intern_state_ = intern_state::stop;
 
   // Close the socket and register error if there was no stop error before
   if (boost::system::error_code close_error = close_socket())
@@ -887,7 +887,7 @@ void session::start_stop(boost::system::error_code error)
   }
 
   // Notify wait handler if need
-  if (ext_state::work == ext_state_)
+  if (extern_state::work == extern_state_)
   {
     complete_extern_wait(error);
   }
@@ -912,17 +912,17 @@ void session::start_socket_read(
 
     // Split handler based on current internal state
     // that might change during read operation
-    switch (self->int_state_)
+    switch (self->intern_state_)
     {
-    case int_state::work:
+    case intern_state::work:
       self->handle_read_at_work(error, bytes_transferred);
       break;
 
-    case int_state::shutdown:
+    case intern_state::shutdown:
       self->handle_read_at_shutdown(error, bytes_transferred);
       break;
 
-    case int_state::stop:
+    case intern_state::stop:
       self->handle_read_at_stop(error, bytes_transferred);
       break;
 
@@ -968,17 +968,17 @@ void session::start_socket_write(
 
     // Split handler based on current internal state
     // that might change during write operation
-    switch (self->int_state_)
+    switch (self->intern_state_)
     {
-    case int_state::work:
+    case intern_state::work:
       self->handle_write_at_work(error, bytes_transferred);
       break;
 
-    case int_state::shutdown:
+    case intern_state::shutdown:
       self->handle_write_at_shutdown(error, bytes_transferred);
       break;
 
-    case int_state::stop:
+    case intern_state::stop:
       self->handle_write_at_stop(error, bytes_transferred);
       break;
 
@@ -1026,14 +1026,14 @@ void session::start_timer_wait()
 
     // Split handler based on current internal state
     // that might change during timer wait operation
-    switch (self->int_state_)
+    switch (self->intern_state_)
     {
-    case int_state::work:
-    case int_state::shutdown:
+    case intern_state::work:
+    case intern_state::shutdown:
       self->handle_timer_at_work(error);
       break;
 
-    case int_state::stop:
+    case intern_state::stop:
       self->handle_timer_at_stop(error);
       break;
 

--- a/src/ma/echo/server/session.cpp
+++ b/src/ma/echo/server/session.cpp
@@ -37,7 +37,7 @@ public:
   template <typename SessionPtr>
   io_handler_binder(func_type func, SessionPtr&& session)
     : func_(func)
-    , session_(std::forward<SessionPtr>(session))
+    , session_(detail::forward<SessionPtr>(session))
   {
   }
 
@@ -45,7 +45,7 @@ public:
 
   io_handler_binder(this_type&& other)
     : func_(other.func_)
-    , session_(std::move(other.session_))
+    , session_(detail::move(other.session_))
   {
   }
 
@@ -81,7 +81,7 @@ public:
   template <typename SessionPtr>
   timer_handler_binder(func_type func, SessionPtr&& session)
     : func_(func)
-    , session_(std::forward<SessionPtr>(session))
+    , session_(detail::forward<SessionPtr>(session))
   {
   }
 
@@ -89,7 +89,7 @@ public:
 
   timer_handler_binder(this_type&& other)
     : func_(other.func_)
-    , session_(std::move(other.session_))
+    , session_(detail::move(other.session_))
   {
   }
 

--- a/src/ma/echo/server/session_manager.cpp
+++ b/src/ma/echo/server/session_manager.cpp
@@ -49,7 +49,7 @@ public:
   session_ptr release()
   {
 #if defined(MA_HAS_RVALUE_REFS)
-    return std::move(session_);
+    return detail::move(session_);
 #else
     session_ptr tmp;
     tmp.swap(session_);
@@ -83,8 +83,8 @@ public:
   accept_handler_binder(func_type func, SessionManagerPtr&& session_manager,
       SessionWrapperPtr&& session)
     : func_(func)
-    , session_manager_(std::forward<SessionManagerPtr>(session_manager))
-    , session_(std::forward<SessionWrapperPtr>(session))
+    , session_manager_(detail::forward<SessionManagerPtr>(session_manager))
+    , session_(detail::forward<SessionWrapperPtr>(session))
   {
   }
 
@@ -92,8 +92,8 @@ public:
 
   accept_handler_binder(this_type&& other)
     : func_(other.func_)
-    , session_manager_(std::move(other.session_manager_))
-    , session_(std::move(other.session_))
+    , session_manager_(detail::move(other.session_manager_))
+    , session_(detail::move(other.session_))
   {
   }
 
@@ -133,8 +133,8 @@ public:
   session_dispatch_binder(func_type func, SessionManagerPtr&& session_manager,
       SessionWrapperPtr&& session)
     : func_(func)
-    , session_manager_(std::forward<SessionManagerPtr>(session_manager))
-    , session_(std::forward<SessionWrapperPtr>(session))
+    , session_manager_(detail::forward<SessionManagerPtr>(session_manager))
+    , session_(detail::forward<SessionWrapperPtr>(session))
   {
   }
 
@@ -142,8 +142,8 @@ public:
 
   session_dispatch_binder(this_type&& other)
     : func_(other.func_)
-    , session_manager_(std::move(other.session_manager_))
-    , session_(std::move(other.session_))
+    , session_manager_(detail::move(other.session_manager_))
+    , session_(detail::move(other.session_))
   {
   }
 
@@ -183,8 +183,8 @@ public:
   session_handler_binder(func_type func, SessionManagerPtr&& session_manager,
       SessionWrapperPtr&& session, const boost::system::error_code& error)
     : func_(func)
-    , session_manager_(std::forward<SessionManagerPtr>(session_manager))
-    , session_(std::forward<SessionWrapperPtr>(session))
+    , session_manager_(detail::forward<SessionManagerPtr>(session_manager))
+    , session_(detail::forward<SessionWrapperPtr>(session))
     , error_(error)
   {
   }
@@ -193,9 +193,9 @@ public:
 
   session_handler_binder(this_type&& other)
     : func_(other.func_)
-    , session_manager_(std::move(other.session_manager_))
-    , session_(std::move(other.session_))
-    , error_(std::move(other.error_))
+    , session_manager_(detail::move(other.session_manager_))
+    , session_(detail::move(other.session_))
+    , error_(detail::move(other.error_))
   {
   }
 
@@ -345,7 +345,7 @@ public:
   session_ptr detach()
   {
 #if defined(MA_HAS_RVALUE_REFS)
-    return std::move(session_);
+    return detail::move(session_);
 #else
     session_ptr tmp;
     tmp.swap(session_);
@@ -418,59 +418,29 @@ public:
     state_ = state_type::work;
   }
 
-#if defined(MA_HAS_RVALUE_REFS)
-
   template <typename Handler>
-  void async_start(Handler&& handler)
+  void async_start(Handler MA_FWD_REF handler)
   {
     session_->async_start(make_custom_alloc_handler(
-        start_wait_allocator_, std::forward<Handler>(handler)));
+        start_wait_allocator_, detail::forward<Handler>(handler)));
     start_started();
   }
 
   template <typename Handler>
-  void async_stop(Handler&& handler)
+  void async_stop(Handler MA_FWD_REF handler)
   {
     session_->async_stop(make_custom_alloc_handler(
-        stop_allocator_, std::forward<Handler>(handler)));
+        stop_allocator_, detail::forward<Handler>(handler)));
     stop_started();
   }
 
   template <typename Handler>
-  void async_wait(Handler&& handler)
+  void async_wait(Handler MA_FWD_REF handler)
   {
     session_->async_wait(make_custom_alloc_handler(
-        start_wait_allocator_, std::forward<Handler>(handler)));
+        start_wait_allocator_, detail::forward<Handler>(handler)));
     wait_started();
   }
-
-#else // defined(MA_HAS_RVALUE_REFS)
-
-  template <typename Handler>
-  void async_start(const Handler& handler)
-  {
-    session_->async_start(make_custom_alloc_handler(
-        start_wait_allocator_, handler));
-    start_started();
-  }
-
-  template <typename Handler>
-  void async_stop(const Handler& handler)
-  {
-    session_->async_stop(make_custom_alloc_handler(
-        stop_allocator_, handler));
-    stop_started();
-  }
-
-  template <typename Handler>
-  void async_wait(const Handler& handler)
-  {
-    session_->async_wait(make_custom_alloc_handler(
-        start_wait_allocator_, handler));
-    wait_started();
-  }
-
-#endif // defined(MA_HAS_RVALUE_REFS)
 
 private:
   void start_started()

--- a/src/ma/echo/server/session_manager.cpp
+++ b/src/ma/echo/server/session_manager.cpp
@@ -64,9 +64,7 @@ private:
 
 } // anonymous namespace
 
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR) \
-    && !(defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
+#if defined(MA_HAS_RVALUE_REFS) && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
 // Home-grown binders to support move semantic
 class session_manager::accept_handler_binder
@@ -225,8 +223,6 @@ private:
 
 #endif // defined(MA_HAS_RVALUE_REFS)
        //     && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
-       //     && !(defined(MA_HAS_LAMBDA)
-       //         && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
 
 session_manager::stats_collector::stats_collector()
   : mutex_()
@@ -714,9 +710,6 @@ void session_manager::continue_work()
   start_accept_session(session);
 }
 
-#if !(defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
-
 void session_manager::handle_accept(const session_wrapper_ptr& session,
     const boost::system::error_code& error)
 {
@@ -803,10 +796,6 @@ void session_manager::handle_session_stop(const session_wrapper_ptr& session,
     break;
   }
 }
-
-#endif // !(defined(MA_HAS_RVALUE_REFS)
-       //     && defined(MA_HAS_LAMBDA)
-       //     && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
 
 void session_manager::handle_accept_at_work(const session_wrapper_ptr& session,
     const boost::system::error_code& error)
@@ -1144,37 +1133,6 @@ session_manager::session_wrapper_ptr session_manager::start_active_session_stop(
   return begin;
 }
 
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
-void session_manager::schedule_active_session_stop()
-{
-  session_manager_ptr self = shared_from_this();
-
-  io_service_.post(strand_.wrap(ma::make_custom_alloc_handler(
-      session_stop_allocator_, [self]()
-  {
-    --self->pending_operations_;
-
-    self->stopping_sessions_end_ =
-        self->start_active_session_stop(
-            self->stopping_sessions_end_,
-            self->max_stopping_sessions_);
-    if (self->stopping_sessions_end_)
-    {
-      self->schedule_active_session_stop();
-    }
-
-    self->continue_stop();
-  })));
-
-  ++pending_operations_;
-}
-
-#else // defined(MA_HAS_RVALUE_REFS)
-      //     && defined(MA_HAS_LAMBDA)
-      //     && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
 void session_manager::schedule_active_session_stop()
 {
   io_service_.post(strand_.wrap(ma::make_custom_alloc_handler(
@@ -1198,44 +1156,9 @@ void session_manager::handle_scheduled_active_session_stop()
   continue_stop();
 }
 
-#endif // defined(MA_HAS_RVALUE_REFS)
-       //     && defined(MA_HAS_LAMBDA)
-       //     && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
 void session_manager::start_accept_session(const session_wrapper_ptr& session)
 {
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
-  session_manager_ptr self = shared_from_this();
-
-  acceptor_.async_accept(session->socket(), session->remote_endpoint(),
-      strand_.wrap(make_custom_alloc_handler(accept_allocator_,
-          [self, session](const boost::system::error_code& error)
-  {
-    BOOST_ASSERT_MSG(accept_state::in_progress == self->accept_state_,
-        "Invalid accept state");
-
-    // Split handler based on current internal state
-    // that might change during accept operation
-    switch (self->intern_state_)
-    {
-    case intern_state::work:
-      self->handle_accept_at_work(session, error);
-      break;
-
-    case intern_state::stop:
-      self->handle_accept_at_stop(session, error);
-      break;
-
-    default:
-      BOOST_ASSERT_MSG(false, "Invalid internal state");
-      break;
-    }
-  })));
-
-#elif defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
+#if defined(MA_HAS_RVALUE_REFS) && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
   acceptor_.async_accept(session->socket(), session->remote_endpoint(),
       strand_.wrap(make_custom_alloc_handler(accept_allocator_,
@@ -1259,41 +1182,7 @@ void session_manager::start_session_start(const session_wrapper_ptr& session)
 {
   // Asynchronously start wrapped session
 
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
-  session_manager_weak_ptr weak_this = shared_from_this();
-
-  session->async_start(
-      [weak_this, session](const boost::system::error_code& error)
-  {
-    if (session_manager_ptr this_ptr = weak_this.lock())
-    {
-      this_ptr->strand_.dispatch(make_custom_alloc_handler(
-          session->start_allocator(), [this_ptr, session, error]()
-      {
-        // Split handler based on current internal state
-        // that might change during session start
-        switch (this_ptr->intern_state_)
-        {
-        case intern_state::work:
-          this_ptr->handle_session_start_at_work(session, error);
-          break;
-
-        case intern_state::stop:
-          this_ptr->handle_session_start_at_stop(session, error);
-          break;
-
-        default:
-          BOOST_ASSERT_MSG(false, "Invalid internal state");
-          break;
-        }
-      }));
-    }
-  });
-
-#elif defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
+#if defined(MA_HAS_RVALUE_REFS) && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
   session->async_start(session_dispatch_binder(
       &this_type::dispatch_handle_session_start, shared_from_this(), session));
@@ -1313,41 +1202,7 @@ void session_manager::start_session_stop(const session_wrapper_ptr& session)
 {
   // Asynchronously stop wrapped session
 
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
-  session_manager_weak_ptr weak_this = shared_from_this();
-
-  session->async_stop(
-      [weak_this, session](const boost::system::error_code& error)
-  {
-    if (session_manager_ptr this_ptr = weak_this.lock())
-    {
-      this_ptr->strand_.dispatch(make_custom_alloc_handler(
-          session->stop_allocator(), [this_ptr, session, error]()
-      {
-        // Split handler based on current internal state
-        // that might change during session stop
-        switch (this_ptr->intern_state_)
-        {
-        case intern_state::work:
-          this_ptr->handle_session_stop_at_work(session, error);
-          break;
-
-        case intern_state::stop:
-          this_ptr->handle_session_stop_at_stop(session, error);
-          break;
-
-        default:
-          BOOST_ASSERT_MSG(false, "Invalid internal state");
-          break;
-        }
-      }));
-    }
-  });
-
-#elif defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
+#if defined(MA_HAS_RVALUE_REFS) && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
   session->async_stop(session_dispatch_binder(
       &this_type::dispatch_handle_session_stop, shared_from_this(), session));
@@ -1367,41 +1222,7 @@ void session_manager::start_session_wait(const session_wrapper_ptr& session)
 {
   // Asynchronously wait on wrapped session
 
-#if defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR)
-
-  session_manager_weak_ptr weak_this = shared_from_this();
-
-  session->async_wait(
-      [weak_this, session](const boost::system::error_code& error)
-  {
-    if (session_manager_ptr this_ptr = weak_this.lock())
-    {
-      this_ptr->strand_.dispatch(make_custom_alloc_handler(
-          session->wait_allocator(), [this_ptr, session, error]()
-      {
-        // Split handler based on current internal state
-        // that might change during session wait
-        switch (this_ptr->intern_state_)
-        {
-        case intern_state::work:
-          this_ptr->handle_session_wait_at_work(session, error);
-          break;
-
-        case intern_state::stop:
-          this_ptr->handle_session_wait_at_stop(session, error);
-          break;
-
-        default:
-          BOOST_ASSERT_MSG(false, "Invalid internal state");
-          break;
-        }
-      }));
-    }
-  });
-
-#elif defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
+#if defined(MA_HAS_RVALUE_REFS) && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
   session->async_wait(session_dispatch_binder(
       &this_type::dispatch_handle_session_wait, shared_from_this(), session));
@@ -1529,9 +1350,6 @@ boost::system::error_code session_manager::close_acceptor()
   return error;
 }
 
-#if !(defined(MA_HAS_RVALUE_REFS) \
-    && defined(MA_HAS_LAMBDA) && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
-
 void session_manager::dispatch_handle_session_start(
     const session_manager_weak_ptr& this_weak_ptr,
     const session_wrapper_ptr& session,
@@ -1606,10 +1424,6 @@ void session_manager::dispatch_handle_session_stop(
 #endif
   }
 }
-
-#endif // !(defined(MA_HAS_RVALUE_REFS)
-       //     && defined(MA_HAS_LAMBDA)
-      //      && !defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR))
 
 void session_manager::open(protocol_type::acceptor& acceptor,
     const protocol_type::endpoint& endpoint, int backlog,

--- a/src/ma/echo/server/session_manager.cpp
+++ b/src/ma/echo/server/session_manager.cpp
@@ -599,7 +599,7 @@ session_manager::optional_error_code session_manager::do_start_extern_stop()
     start_stop(server::error::operation_aborted);
   }
 
-  // int_state_ can be changed by start_stop
+  // intern_state_ can be changed by start_stop
   if (intern_state::stopped == intern_state_)
   {
     extern_state_ = extern_state::stopped;
@@ -725,13 +725,13 @@ void session_manager::handle_accept(const session_wrapper_ptr& session,
 
   // Split handler based on current internal state
   // that might change during accept operation
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_accept_at_work(session, error);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_accept_at_stop(session, error);
     break;
 
@@ -746,13 +746,13 @@ void session_manager::handle_session_start(const session_wrapper_ptr& session,
 {
   // Split handler based on current internal state
   // that might change during session start
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_session_start_at_work(session, error);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_session_start_at_stop(session, error);
     break;
 
@@ -767,13 +767,13 @@ void session_manager::handle_session_wait(const session_wrapper_ptr& session,
 {
   // Split handler based on current internal state
   // that might change during session wait
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_session_wait_at_work(session, error);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_session_wait_at_stop(session, error);
     break;
 
@@ -788,13 +788,13 @@ void session_manager::handle_session_stop(const session_wrapper_ptr& session,
 {
   // Split handler based on current internal state
   // that might change during session stop
-  switch (int_state_)
+  switch (intern_state_)
   {
-  case int_state::work:
+  case intern_state::work:
     handle_session_stop_at_work(session, error);
     break;
 
-  case int_state::stop:
+  case intern_state::stop:
     handle_session_stop_at_stop(session, error);
     break;
 


### PR DESCRIPTION
* Fixed support of Visual C++ 2013. 
* qt_echo_server & echo_server projects: lambdas were removed in order to unify code base, std::move was replaced with wrapper.
* Unified work with std::move && std::forward via wrappers.