### PR TITLE
nmea_client: passing parameters of `async_` functions by value

### DIFF
--- a/build/cmake/compiler_options.cmake
+++ b/build/cmake/compiler_options.cmake
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (c) 2010-2015 Marat Abrarov (abrarov@gmail.com)
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,9 +7,15 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
-# Turn on pthread usage
+# Turn on thread support for GCC
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "-pthread ${CMAKE_CXX_FLAGS}")
+    if(MINGW)
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -mthreads")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mthreads")
+    else()
+        set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -pthread")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+    endif()
 endif()
 
 # Turn on support of C++11 if it's available

--- a/include/ma/nmea/cyclic_read_session.hpp
+++ b/include/ma/nmea/cyclic_read_session.hpp
@@ -72,11 +72,11 @@ public:
 
   // Handler()(const boost::system::error_code&, std::size_t)
   template <typename Handler, typename Iterator>
-  void async_read_some(Iterator MA_FWD_REF begin, Iterator MA_FWD_REF end, 
+  void async_read_some(Iterator begin, Iterator end, 
       Handler MA_FWD_REF handler);
 
   template <typename ConstBufferSequence, typename Handler>
-  void async_write_some(ConstBufferSequence MA_FWD_REF buffers, 
+  void async_write_some(ConstBufferSequence buffers, 
       Handler MA_FWD_REF handler);
 
 protected:
@@ -284,8 +284,7 @@ void cyclic_read_session::async_stop(Handler MA_FWD_REF handler)
 // Handler()(const boost::system::error_code&, std::size_t)
 template <typename Handler, typename Iterator>
 void cyclic_read_session::async_read_some(
-    Iterator MA_FWD_REF begin, Iterator MA_FWD_REF end, 
-    Handler MA_FWD_REF handler)
+    Iterator begin, Iterator end, Handler MA_FWD_REF handler)
 {
   typedef typename remove_cv_reference<Iterator>::type iterator_type;
   typedef typename remove_cv_reference<Handler>::type  handler_type;
@@ -303,7 +302,7 @@ void cyclic_read_session::async_read_some(
 
 template <typename ConstBufferSequence, typename Handler>
 void cyclic_read_session::async_write_some(
-    ConstBufferSequence MA_FWD_REF buffers, Handler MA_FWD_REF handler)
+    ConstBufferSequence buffers, Handler MA_FWD_REF handler)
 {
   typedef typename remove_cv_reference<ConstBufferSequence>::type
       buffers_type;


### PR DESCRIPTION
nmea_client: passing parameters of `async_` functions by value (except completion handler) to eliminate possible usage of destructed objects (if case of lifetime of actual argument is bound to lifetime of handler).