### PR TITLE
GCC warnings fixed

### DIFF
--- a/include/ma/echo/server/session.hpp
+++ b/include/ma/echo/server/session.hpp
@@ -162,7 +162,7 @@ private:
   const std::size_t                   max_transfer_size_;
   const session_config::optional_int  socket_recv_buffer_size_;
   const session_config::optional_int  socket_send_buffer_size_;
-  const session_config::optional_bool no_delay_;
+  const session_config::tribool       no_delay_;
   const optional_duration             inactivity_timeout_;
 
   extern_state::value_t extern_state_;
@@ -223,7 +223,7 @@ private:
   session_ptr session_;
 }; // class session::forward_handler_binder
 
-#endif // defined(MA_HAS_RVALUE_REFS) 
+#endif // defined(MA_HAS_RVALUE_REFS)
        //     && defined(MA_BIND_HAS_NO_MOVE_CONSTRUCTOR)
 
 template <typename Handler>

--- a/include/ma/echo/server/session_config.hpp
+++ b/include/ma/echo/server/session_config.hpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <boost/assert.hpp>
 #include <boost/optional.hpp>
+#include <boost/logic/tribool.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <ma/echo/server/session_config_fwd.hpp>
 
@@ -26,7 +27,7 @@ struct session_config
 {
 public:
   typedef boost::optional<int>             optional_int;
-  typedef boost::optional<bool>            optional_bool;
+  typedef boost::logic::tribool            tribool;
   typedef boost::posix_time::time_duration time_duration;
   typedef boost::optional<time_duration>   optional_time_duration;
 
@@ -35,11 +36,11 @@ public:
       std::size_t max_transfer_size,
       const optional_int& socket_recv_buffer_size = optional_int(),
       const optional_int& socket_send_buffer_size = optional_int(),
-      const optional_bool& no_delay = optional_bool(),
+      const tribool& no_delay = boost::logic::indeterminate,
       const optional_time_duration& inactivity_timeout =
           optional_time_duration());
 
-  optional_bool no_delay;
+  tribool       no_delay;
   optional_int  socket_recv_buffer_size;
   optional_int  socket_send_buffer_size;
   std::size_t   buffer_size;
@@ -52,7 +53,7 @@ inline session_config::session_config(
     std::size_t the_max_transfer_size,
     const optional_int& the_socket_recv_buffer_size,
     const optional_int& the_socket_send_buffer_size,
-    const optional_bool& the_no_delay,
+    const tribool& the_no_delay,
     const optional_time_duration& the_inactivity_timeout)
   : no_delay(the_no_delay)
   , socket_recv_buffer_size(the_socket_recv_buffer_size)

--- a/src/ma/echo/server/qt/mainform.cpp
+++ b/src/ma/echo/server/qt/mainform.cpp
@@ -12,6 +12,7 @@ TRANSLATOR ma::echo::server::qt::MainForm
 #include <limits>
 #include <stdexcept>
 #include <boost/optional.hpp>
+#include <boost/logic/tribool.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <QtGlobal>
@@ -426,7 +427,7 @@ session_config MainForm::buildSessionConfig() const
   boost::optional<int> socketSendBufferSize = readOptionalValue(
       *ui_.sockSendBufferSizeCheckBox, *ui_.sockSendBufferSizeSpinBox);
 
-  boost::optional<bool> tcpNoDelay;
+  boost::logic::tribool tcpNoDelay = boost::logic::indeterminate;
   switch (ui_.tcpNoDelayComboBox->currentIndex())
   {
   case 1:
@@ -491,7 +492,7 @@ session_manager_config MainForm::buildSessionManagerConfig() const
 
   return session_manager_config(
       boost::asio::ip::tcp::endpoint(listenAddress, port),
-      maxSessions, recycledSessions, maxStoppingSessions, listenBacklog, 
+      maxSessions, recycledSessions, maxStoppingSessions, listenBacklog,
       buildSessionConfig());
 }
 

--- a/src/ma/echo/server/session.cpp
+++ b/src/ma/echo/server/session.cpp
@@ -6,6 +6,7 @@
 //
 
 #include <boost/assert.hpp>
+#include <boost/logic/tribool.hpp>
 #include <ma/config.hpp>
 #include <ma/shared_ptr_factory.hpp>
 #include <ma/custom_alloc_handler.hpp>
@@ -995,7 +996,7 @@ boost::system::error_code session::apply_socket_options()
     }
   }
 
-  // Apply all (really) configered socket options
+  // Apply all (really) configured socket options
   if (socket_recv_buffer_size_)
   {
     boost::system::error_code error;
@@ -1018,10 +1019,10 @@ boost::system::error_code session::apply_socket_options()
     }
   }
 
-  if (no_delay_)
+  if (!boost::logic::indeterminate(no_delay_))
   {
     boost::system::error_code error;
-    protocol_type::no_delay opt(*no_delay_);
+    protocol_type::no_delay opt(static_cast<bool>(no_delay_));
     socket_.set_option(opt, error);
     if (error)
     {


### PR DESCRIPTION
Replaced usage of boost::optional<bool> with boost::logic::tribool to eliminate GCC warnings (false warnings about uninitialized memory access).