### PR TITLE
Feature/console close guard

### DIFF
--- a/include/ma/console_close_guard.hpp
+++ b/include/ma/console_close_guard.hpp
@@ -16,12 +16,10 @@
 #include <boost/asio.hpp>
 #include <ma/config.hpp>
 #include <ma/type_traits.hpp>
-#include <ma/handler_invoke_helpers.hpp>
 #include <ma/context_alloc_handler.hpp>
 #include <ma/console_close_signal.hpp>
 #include <ma/detail/functional.hpp>
 #include <ma/detail/thread.hpp>
-#include <ma/detail/tuple.hpp>
 #include <ma/detail/utility.hpp>
 
 namespace ma {
@@ -99,7 +97,7 @@ void console_close_guard_base::handle_signal(console_close_signal& close_signal,
     // twice without asio_handler_deallocate between (but the number
     // of calls of asio_handler_allocate will keep being the same
     // as the number of calls of asio_handler_deallocate).
-    ma_handler_invoke_helpers::invoke(handler, handler);
+    close_signal.get_io_service().dispatch(handler);
   }
 }
 

--- a/include/ma/context_invoke_handler.hpp
+++ b/include/ma/context_invoke_handler.hpp
@@ -17,11 +17,8 @@
 #include <ma/handler_alloc_helpers.hpp>
 #include <ma/handler_invoke_helpers.hpp>
 #include <ma/handler_cont_helpers.hpp>
-
-#if defined(MA_HAS_RVALUE_REFS)
-#include <utility>
 #include <ma/type_traits.hpp>
-#endif // defined(MA_HAS_RVALUE_REFS)
+#include <ma/detail/utility.hpp>
 
 namespace ma {
 
@@ -41,20 +38,19 @@ private:
 public:
   typedef void result_type;
 
-#if defined(MA_HAS_RVALUE_REFS)
-
   template <typename C, typename H>
-  context_invoke_handler(C&& context, H&& handler)
-    : context_(std::forward<C>(context))
-    , handler_(std::forward<H>(handler))
+  context_invoke_handler(MA_FWD_REF(C) context, MA_FWD_REF(H) handler)
+    : context_(detail::forward<C>(context))
+    , handler_(detail::forward<H>(handler))
   {
   }
 
-#if defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR) || !defined(NDEBUG)
+#if defined(MA_HAS_RVALUE_REFS) \
+    && (defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR) || !defined(NDEBUG))
 
   context_invoke_handler(this_type&& other)
-    : context_(std::move(other.context_))
-    , handler_(std::move(other.handler_))
+    : context_(detail::move(other.context_))
+    , handler_(detail::move(other.handler_))
   {
   }
 
@@ -65,16 +61,6 @@ public:
   }
 
 #endif
-
-#else // defined(MA_HAS_RVALUE_REFS)
-
-  context_invoke_handler(const Context& context, const Handler& handler)
-    : context_(context)
-    , handler_(handler)
-  {
-  }
-
-#endif // defined(MA_HAS_RVALUE_REFS)
 
 #if !defined(NDEBUG)
   ~context_invoke_handler()
@@ -100,11 +86,12 @@ public:
 #if defined(MA_HAS_RVALUE_REFS)
 
   template <typename Function>
-  friend void asio_handler_invoke(Function&& function, this_type* context)
+  friend void asio_handler_invoke(MA_FWD_REF(Function) function,
+      this_type* context)
   {
     // Forward to asio_handler_invoke provided by source handler.
     ma_handler_invoke_helpers::invoke(
-        std::forward<Function>(function), context->context_);
+        detail::forward<Function>(function), context->context_);
   }
 
 #else // defined(MA_HAS_RVALUE_REFS)
@@ -136,36 +123,41 @@ public:
   }
 
   template <typename Arg1>
-  void operator()(const Arg1& arg1)
+  void operator()(MA_FWD_REF(Arg1) arg1)
   {
-    handler_(arg1);
+    handler_(detail::forward<Arg1>(arg1));
   }
 
   template <typename Arg1, typename Arg2>
-  void operator()(const Arg1& arg1, const Arg2& arg2)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2)
   {
-    handler_(arg1, arg2);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3)
   {
-    handler_(arg1, arg2, arg3);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4)
   {
-    handler_(arg1, arg2, arg3, arg4);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
       typename Arg5>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4, const Arg5& arg5)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4, MA_FWD_REF(Arg5) arg5)
   {
-    handler_(arg1, arg2, arg3, arg4, arg5);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4),
+        detail::forward<Arg5>(arg5));
   }
 
   void operator()() const
@@ -174,36 +166,41 @@ public:
   }
 
   template <typename Arg1>
-  void operator()(const Arg1& arg1) const
+  void operator()(MA_FWD_REF(Arg1) arg1) const
   {
-    handler_(arg1);
+    handler_(detail::forward<Arg1>(arg1));
   }
 
   template <typename Arg1, typename Arg2>
-  void operator()(const Arg1& arg1, const Arg2& arg2) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2) const
   {
-    handler_(arg1, arg2);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3) const
   {
-    handler_(arg1, arg2, arg3);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4) const
   {
-    handler_(arg1, arg2, arg3, arg4);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
       typename Arg5>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4, const Arg5& arg5) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4, MA_FWD_REF(Arg5) arg5) const
   {
-    handler_(arg1, arg2, arg3, arg4, arg5);
+    handler_(detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4),
+        detail::forward<Arg5>(arg5));
   }
 
 private:
@@ -215,32 +212,19 @@ private:
 #pragma warning(pop)
 #endif // #if defined(_MSC_VER)
 
-#if defined(MA_HAS_RVALUE_REFS)
-
 /// Helper for creation of wrapped handler.
 template <typename Context, typename Handler>
 inline context_invoke_handler<
     typename remove_cv_reference<Context>::type,
     typename remove_cv_reference<Handler>::type>
-make_context_invoke_handler(Context&& context, Handler&& handler)
+make_context_invoke_handler(MA_FWD_REF(Context) context,
+    MA_FWD_REF(Handler) handler)
 {
   typedef typename remove_cv_reference<Context>::type context_type;
   typedef typename remove_cv_reference<Handler>::type handler_type;
   return context_invoke_handler<context_type, handler_type>(
-      std::forward<Context>(context), std::forward<Handler>(handler));
+      detail::forward<Context>(context), detail::forward<Handler>(handler));
 }
-
-#else // defined(MA_HAS_RVALUE_REFS)
-
-/// Helper for creation of wrapped handler.
-template <typename Context, typename Handler>
-inline context_invoke_handler<Context, Handler>
-make_context_invoke_handler(const Context& context, const Handler& handler)
-{
-  return context_invoke_handler<Context, Handler>(context, handler);
-}
-
-#endif // defined(MA_HAS_RVALUE_REFS)
 
 /// Specialized version of context_invoke_handler that is optimized for reuse of
 /// specified context by the specified source handler.
@@ -265,20 +249,19 @@ private:
 public:
   typedef void result_type;
 
-#if defined(MA_HAS_RVALUE_REFS)
-
   template <typename C, typename H>
-  explicit_context_invoke_handler(C&& context, H&& handler)
-    : context_(std::forward<C>(context))
-    , handler_(std::forward<H>(handler))
+  explicit_context_invoke_handler(MA_FWD_REF(C) context, MA_FWD_REF(H) handler)
+    : context_(detail::forward<C>(context))
+    , handler_(detail::forward<H>(handler))
   {
   }
 
-#if defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR) || !defined(NDEBUG)
+#if defined(MA_HAS_RVALUE_REFS) \
+    && (defined(MA_NO_IMPLICIT_MOVE_CONSTRUCTOR) || !defined(NDEBUG))
 
   explicit_context_invoke_handler(this_type&& other)
-    : context_(std::move(other.context_))
-    , handler_(std::move(other.handler_))
+    : context_(detail::move(other.context_))
+    , handler_(detail::move(other.handler_))
   {
   }
 
@@ -289,17 +272,6 @@ public:
   }
 
 #endif
-
-#else // defined(MA_HAS_RVALUE_REFS)
-
-  explicit_context_invoke_handler(
-      const Context& context, const Handler& handler)
-    : context_(context)
-    , handler_(handler)
-  {
-  }
-
-#endif // defined(MA_HAS_RVALUE_REFS)
 
 #if !defined(NDEBUG)
   ~explicit_context_invoke_handler()
@@ -321,10 +293,11 @@ public:
 #if defined(MA_HAS_RVALUE_REFS)
 
   template <typename Function>
-  friend void asio_handler_invoke(Function&& function, this_type* context)
+  friend void asio_handler_invoke(MA_FWD_REF(Function) function,
+      this_type* context)
   {
     ma_handler_invoke_helpers::invoke(
-        std::forward<Function>(function), context->context_);
+        detail::forward<Function>(function), context->context_);
   }
 
 #else // defined(MA_HAS_RVALUE_REFS)
@@ -350,41 +323,46 @@ public:
 
   void operator()()
   {
-    handler_(static_cast<const Context&>(context_));
+    handler_(context_);
   }
 
   template <typename Arg1>
-  void operator()(const Arg1& arg1)
+  void operator()(MA_FWD_REF(Arg1) arg1)
   {
-    handler_(static_cast<const Context&>(context_), arg1);
+    handler_(context_, detail::forward<Arg1>(arg1));
   }
 
   template <typename Arg1, typename Arg2>
-  void operator()(const Arg1& arg1, const Arg2& arg2)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2);
+    handler_(context_, detail::forward<Arg1>(arg1),
+        detail::forward<Arg2>(arg2));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
       typename Arg5>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4, const Arg5& arg5)
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4, MA_FWD_REF(Arg5) arg5)
   {
-    handler_(static_cast<const Context&>(context_), arg1, arg2, arg3, arg4,
-        arg5);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4),
+        detail::forward<Arg5>(arg5));
   }
 
   void operator()() const
@@ -393,36 +371,41 @@ public:
   }
 
   template <typename Arg1>
-  void operator()(const Arg1& arg1) const
+  void operator()(MA_FWD_REF(Arg1) arg1) const
   {
-    handler_(context_, arg1);
+    handler_(context_, detail::forward<Arg1>(arg1));
   }
 
   template <typename Arg1, typename Arg2>
-  void operator()(const Arg1& arg1, const Arg2& arg2) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2) const
   {
-    handler_(context_, arg1, arg2);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3) const
   {
-    handler_(context_, arg1, arg2, arg3);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4) const
   {
-    handler_(context_, arg1, arg2, arg3, arg4);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4));
   }
 
   template <typename Arg1, typename Arg2, typename Arg3, typename Arg4,
       typename Arg5>
-  void operator()(const Arg1& arg1, const Arg2& arg2, const Arg3& arg3,
-      const Arg4& arg4, const Arg5& arg5) const
+  void operator()(MA_FWD_REF(Arg1) arg1, MA_FWD_REF(Arg2) arg2,
+      MA_FWD_REF(Arg3) arg3, MA_FWD_REF(Arg4) arg4, MA_FWD_REF(Arg5) arg5) const
   {
-    handler_(context_, arg1, arg2, arg3, arg4, arg5);
+    handler_(context_, detail::forward<Arg1>(arg1), detail::forward<Arg2>(arg2),
+        detail::forward<Arg3>(arg3), detail::forward<Arg4>(arg4),
+        detail::forward<Arg5>(arg5));
   }
 
 private:
@@ -434,31 +417,18 @@ private:
 #pragma warning(pop)
 #endif // #if defined(_MSC_VER)
 
-#if defined(MA_HAS_RVALUE_REFS)
-
 template <typename Context, typename Handler>
 inline explicit_context_invoke_handler<
     typename remove_cv_reference<Context>::type,
     typename remove_cv_reference<Handler>::type>
-make_explicit_context_invoke_handler(Context&& context, Handler&& handler)
+make_explicit_context_invoke_handler(MA_FWD_REF(Context) context,
+    MA_FWD_REF(Handler) handler)
 {
   typedef typename remove_cv_reference<Context>::type context_type;
   typedef typename remove_cv_reference<Handler>::type handler_type;
   return explicit_context_invoke_handler<context_type, handler_type>(
-      std::forward<Context>(context), std::forward<Handler>(handler));
+      detail::forward<Context>(context), detail::forward<Handler>(handler));
 }
-
-#else // defined(MA_HAS_RVALUE_REFS)
-
-template <typename Context, typename Handler>
-inline explicit_context_invoke_handler<Context, Handler>
-make_explicit_context_invoke_handler(const Context& context,
-    const Handler& handler)
-{
-  return explicit_context_invoke_handler<Context, Handler>(context, handler);
-}
-
-#endif // defined(MA_HAS_RVALUE_REFS)
 
 } // namespace ma
 


### PR DESCRIPTION
ma::console_close_guard class revisited:

* console_close_guard: removed explicit handler invocation.
* сonsole_close_guard: limited implementation with 1 shot.
