### PR TITLE
Feature/intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,26 @@ option(ma_coverage_build "Add coverage flags for compiler and linker" OFF)
 # Additional helpers
 include(cmake/internal_utils.cmake)
 
-# Common target properties (CMAKE_CXX_FLAGS)
+# Get full list of build configurations
 set(configuration_types ${CMAKE_CONFIGURATION_TYPES})
 if(NOT configuration_types AND DEFINED CMAKE_BUILD_TYPE)
     list(APPEND configuration_types ${CMAKE_BUILD_TYPE})
 endif()
+
+# Common target properties (CMAKE_CXX_FLAGS)
 change_default_compile_options("${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS)
 foreach(configuration_type IN LISTS configuration_types)
     string(TOUPPER ${configuration_type} configuration_type_upper_case)
     set(configuration_cxx_flags CMAKE_CXX_FLAGS_${configuration_type_upper_case})
     change_default_compile_options("${${configuration_cxx_flags}}" ${configuration_cxx_flags})
+endforeach(configuration_type)
+
+# Common target properties (CMAKE_EXE_LINKER_FLAGS)
+change_default_link_options("${CMAKE_EXE_LINKER_FLAGS}" CMAKE_EXE_LINKER_FLAGS)
+foreach(configuration_type IN LISTS configuration_types)
+    string(TOUPPER ${configuration_type} configuration_type_upper_case)
+    set(configuration_cxx_flags CMAKE_EXE_LINKER_FLAGS_${configuration_type_upper_case})
+    change_default_link_options("${${configuration_cxx_flags}}" ${configuration_cxx_flags})
 endforeach(configuration_type)
 
 # Interface-only target for turning on code coverage

--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ cmake -D ICU_ROOT=<ICU root directory>
 
 Remarks: use [this fix](https://software.intel.com/en-us/articles/limits1120-error-identifier-builtin-nanf-is-undefined) when using Intel C++ Compiler 16.0 with Visual Studio 2015 Update 1.
 
+Example of generation of Visual Studio 2015 project (static C/C++ runtime, static Boost and no Qt, x64) for usage with Intel Parallel Studio XE 2017:
+
+```
+cmake -D CMAKE_USER_MAKE_RULES_OVERRIDE=<asio_samples directory>/cmake/static_c_runtime_overrides.cmake
+      -D CMAKE_USER_MAKE_RULES_OVERRIDE_CXX=<asio_samples directory>/cmake/static_cxx_runtime_overrides.cmake
+      -D BOOST_INCLUDEDIR=<Boost headers directory>
+      -D BOOST_LIBRARYDIR=<Boost built libraries directory>
+      -D Boost_NO_SYSTEM_PATHS=ON
+      -D Boost_USE_STATIC_LIBS=ON
+      -D ma_qt=OFF
+      -D CMAKE_C_COMPILER=icl
+      -D CMAKE_CXX_COMPILER=icl
+      -T "Intel C++ Compiler 17.0"
+      -G "Visual Studio 14 2015 Win64"
+      <asio_samples directory>
+```
+
 Example of generation of Visual Studio 2010 project (shared C/C++ runtime, static Boost and shared Qt 4):
 
 ```

--- a/cmake/internal_utils.cmake
+++ b/cmake/internal_utils.cmake
@@ -122,6 +122,26 @@ function(change_default_compile_options orignal_compile_options result)
     set(${result} "${compile_options}" PARENT_SCOPE)
 endfunction()
 
+# Changes existing (default) linker options.
+# Parameters:
+#   result - name of list to store link options.
+function(change_default_link_options orignal_link_options result)
+    set(link_options ${orignal_link_options})
+    if(MSVC AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel"))
+        # Disable incremental linking for Intel C++ Compiler because it leads to crash of linker.
+        if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16"))
+            if(link_options MATCHES "/INCREMENTAL:NO")
+                # Nothing to change here
+            elseif(link_options MATCHES "/INCREMENTAL")
+                string(REGEX REPLACE "/INCREMENTAL" "/INCREMENTAL:NO" link_options "${link_options}")
+            else()
+                set(link_options "${link_options} /INCREMENTAL:NO")
+            endif()
+        endif()
+    endif()
+    set(${result} "${link_options}" PARENT_SCOPE)
+endfunction()
+
 # Builds list of additional internal compiler options.
 # Parameters:
 #   result - name of list to store compile options.


### PR DESCRIPTION
* Added description of generation of MSVS project for usage with Intel Parallel Studio XE 2017.
* Fixed error with debug build when Intel C++ Compiler is used (linker crash): added a workaround for Intel C++ Compiler and MSVS - turned off incremental linking for any type of build.