### PR TITLE
Feature/test coverage

### DIFF
--- a/tests/ma_handler_storage_test/src/handler_storage_test.cpp
+++ b/tests/ma_handler_storage_test/src/handler_storage_test.cpp
@@ -842,6 +842,38 @@ TEST(handler_storage, post_with_arg_with_target)
   ASSERT_EQ(test_post_value, out);
 } // TEST(handler_storage, arg)
 
+TEST(handler_storage, post_no_arg_when_empty)
+{
+  typedef ma::handler_storage<void> handler_storage_type;
+  boost::asio::io_service io_service;
+  handler_storage_type handler_storage(io_service);
+  ASSERT_THROW(handler_storage.post(), ma::bad_handler_call);
+} // TEST(handler_storage, post_no_arg_when_empty)
+
+TEST(handler_storage, post_no_arg_with_target_when_empty)
+{
+  typedef ma::handler_storage<void, test_handler_base> handler_storage_type;
+  boost::asio::io_service io_service;
+  handler_storage_type handler_storage(io_service);
+  ASSERT_THROW(handler_storage.post(), ma::bad_handler_call);
+} // TEST(handler_storage, post_no_arg_with_target_when_empty)
+
+TEST(handler_storage, post_with_arg_when_empty)
+{
+  typedef ma::handler_storage<int> handler_storage_type;
+  boost::asio::io_service io_service;
+  handler_storage_type handler_storage(io_service);
+  ASSERT_THROW(handler_storage.post(42), ma::bad_handler_call);
+} // TEST(handler_storage, post_with_arg_when_empty)
+
+TEST(handler_storage, post_with_arg_with_target_when_empty)
+{
+  typedef ma::handler_storage<int, test_handler_base> handler_storage_type;
+  boost::asio::io_service io_service;
+  handler_storage_type handler_storage(io_service);
+  ASSERT_THROW(handler_storage.post(42), ma::bad_handler_call);
+} // TEST(handler_storage, post_with_arg_with_target_when_empty)
+
 } // namespace handler_storage_post
 
 namespace handler_storage_move_support {

--- a/tests/ma_handler_storage_test/src/handler_storage_test.cpp
+++ b/tests/ma_handler_storage_test/src/handler_storage_test.cpp
@@ -376,6 +376,24 @@ private:
   int  value_;
 }; // class handler
 
+TEST(handler_storage, target_when_empty)
+{
+  {
+    typedef ma::handler_storage<int, handler_base> handler_storage_type;
+
+    boost::asio::io_service io_service;
+    handler_storage_type handler_storage(io_service);
+    ASSERT_EQ(0, handler_storage.target());
+  }
+  {
+    typedef ma::handler_storage<int> handler_storage_type;
+
+    boost::asio::io_service io_service;
+    handler_storage_type handler_storage(io_service);
+    ASSERT_EQ(0, handler_storage.target());
+  }
+} // TEST(handler_storage, target_when_empty)
+
 TEST(handler_storage, target)
 {
   typedef ma::handler_storage<int, handler_base> handler_storage_type;


### PR DESCRIPTION
* Added tests for ma::handler_storage::empty, ma::handler_storage::has_target and ma::handler_storage::clear methods.
* Added tests for ma::handler_storage::target method when instance of ma::handler_storage has no associated (stored) handler.
* Added tests for ma::handler_storage::post method when instance of ma::handler_storage has no associated (stored) handler.