### PR TITLE
Feature/cmake cmp0074

### DIFF
--- a/cmake/ma_qt5_core_support/CMakeLists.txt
+++ b/cmake/ma_qt5_core_support/CMakeLists.txt
@@ -33,7 +33,16 @@ if(Qt5Core_FOUND)
 
         list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
+        # ICU_ROOT
+        if(POLICY CMP0074)
+            cmake_policy(PUSH)
+            cmake_policy(SET CMP0074 OLD)
+        endif()
         find_package(ICU REQUIRED COMPONENTS i18n uc data)
+        if(POLICY CMP0074)
+            cmake_policy(POP)
+        endif()
+
         list(APPEND cxx_libraries ${ICU_LIBRARIES})
 
         # Starting from Qt 5.5.0 PCRE library is used by QtCore

--- a/docker/builder/alpine/start.sh
+++ b/docker/builder/alpine/start.sh
@@ -5,7 +5,7 @@ set -e
 
 # Setup required version of Qt if needed
 if [[ "${MA_QT}" = "ON" ]]; then
-    if [ "${MA_QT_MAJOR_VERSION}" -ne 4 ]; then
+    if [[ "${MA_QT_MAJOR_VERSION}" -ne 4 ]]; then
         # Remove Qt 4 to eliminate conflicts with another version of Qt
         apk -q -f del qt-dev || true;
     fi


### PR DESCRIPTION
* Suppressed CMake 3.12+ warning when searching for ICU libraries (when searching for Qt libraries)
* Fixed syntax in script in builder Docker image based on Alpine Linux 