### PR TITLE
CI scripts enhancements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -109,6 +109,7 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 9.0
       RUNTIME_LINKAGE: static
+      CMAKE_VERSION: 3.0.0
       BOOST_VERSION: 1.47.0
       BOOST_LINKAGE: static
       COVERAGE_BUILD_CANDIDATE: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -355,7 +355,7 @@ matrix:
     # GCC 4.6, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 CMAKE_VERSION=3.0.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc46-boost155-qt5
         apt:
@@ -369,7 +369,7 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 CMAKE_VERSION=3.0.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc46-boost155-qt5
     # Clang 4.0, Boost 1.55.0, Qt 5.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -355,7 +355,7 @@ matrix:
     # GCC 4.6, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 CMAKE_VERSION=3.0.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc46-boost155-qt5
         apt:
@@ -369,7 +369,7 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 CMAKE_VERSION=3.0.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc46-boost155-qt5
     # Clang 4.0, Boost 1.55.0, Qt 5.x

--- a/scripts/appveyor/install.ps1
+++ b/scripts/appveyor/install.ps1
@@ -101,8 +101,13 @@ switch (${env:TOOLCHAIN}) {
     throw "Unsupported toolchain: ${env:TOOLCHAIN}"
   }
 }
-$detected_cmake_version = (cmake --version | Where-Object {$_ -match 'cmake version ([0-9]+\.[0-9]+\.[0-9]+)'}) `
-  -replace "cmake version ([0-9]+\.[0-9]+\.[0-9]+)", '$1'
+try {
+  $detected_cmake_version = (cmake --version 2> $null `
+    | Where-Object {$_ -match 'cmake version ([0-9]+\.[0-9]+\.[0-9]+)'}) `
+    -replace "cmake version ([0-9]+\.[0-9]+\.[0-9]+)", '$1'
+} catch {
+  $detected_cmake_version = ""
+}
 Write-Host "Detected CMake of ${detected_cmake_version} version"
 if (Test-Path env:CMAKE_VERSION) {
   Write-Host "CMake of ${env:CMAKE_VERSION} version is requested"

--- a/scripts/appveyor/install.ps1
+++ b/scripts/appveyor/install.ps1
@@ -112,7 +112,12 @@ Write-Host "Detected CMake of ${detected_cmake_version} version"
 if (Test-Path env:CMAKE_VERSION) {
   Write-Host "CMake of ${env:CMAKE_VERSION} version is requested"
   if (${env:CMAKE_VERSION} -ne ${detected_cmake_version}) {
-    $cmake_archive_base_name = "cmake-${env:CMAKE_VERSION}-win64-x64"
+    if ([System.Version] "${env:CMAKE_VERSION}" -ge [System.Version] "3.6.0") {
+      $cmake_archive_base_name = "cmake-${env:CMAKE_VERSION}-win64-x64"
+    } else {
+      # CMake x64 binary is not available for CMake version < 3.6.0
+      $cmake_archive_base_name = "cmake-${env:CMAKE_VERSION}-win32-x86"
+    }
     $cmake_home = "${env:DEPENDENCIES_FOLDER}\${cmake_archive_base_name}"
     if (!(Test-Path -Path "${cmake_home}")) {
       Write-Host "CMake ${env:CMAKE_VERSION} not found at ${cmake_home}"

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,9 +9,8 @@
 
 set -e
 
-this_path="$(cd "$(dirname "${0}")" && pwd)"
 # shellcheck source=travis_retry.sh
-source "${this_path}/travis_retry.sh"
+source "${TRAVIS_BUILD_DIR}/scripts/travis/travis_retry.sh"
 
 codecov_flag="${TRAVIS_OS_NAME}__$(uname -r | sed -r 's/[[:space:]]|[\\\.\/:]/_/g')__${CXX_COMPILER_FAMILY}_$(${CXX_COMPILER} -dumpversion)__boost_${BOOST_VERSION}__qt_${QT_MAJOR_VERSION}"
 codecov_flag="${codecov_flag//[.-]/_}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# shellcheck source=vercomp.sh
+source "${TRAVIS_BUILD_DIR}/scripts/travis/vercomp.sh"
+
 if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
   export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:${PATH}"
 fi
@@ -21,7 +24,12 @@ if [[ -n "${CMAKE_VERSION+x}" ]]; then
   echo "CMake of ${CMAKE_VERSION} version is requested"
   if [[ "${CMAKE_VERSION}" != "${detected_cmake_version}" ]]; then
     if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
-      cmake_archive_base_name="cmake-${CMAKE_VERSION}-Linux-x86_64"
+      if [[ "$(vercomp "${CMAKE_VERSION}" "3.1.0")" -ge 0 ]]; then
+        cmake_archive_base_name="cmake-${CMAKE_VERSION}-Linux-x86_64"
+      else
+        # CMake x64 binary is not available for CMake version < 3.1.0
+        cmake_archive_base_name="cmake-${CMAKE_VERSION}-Linux-i386"
+      fi
       cmake_home="${DEPENDENCIES_HOME}/${cmake_archive_base_name}"
       if [[ ! -d "${cmake_home}" ]]; then
         echo "CMake ${CMAKE_VERSION} not found at ${cmake_home}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -16,7 +16,7 @@ if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
   export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:${PATH}"
 fi
 
-detected_cmake_version="$(cmake --version \
+detected_cmake_version="$({ cmake --version 2> /dev/null || echo ""; } \
   | sed -r 's/cmake version ([0-9]+\.[0-9]+\.[0-9]+)/\1/;t;d')"
 echo "Detected CMake of ${detected_cmake_version} version"
 

--- a/scripts/travis/vercomp.sh
+++ b/scripts/travis/vercomp.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# Copied from https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vercomp() {
+  if [[ "${1}" = "${2}" ]]; then
+    return 0
+  fi
+  local IFS=.
+  local i
+  local ver1=(${1})
+  local ver2=(${2})
+  # fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+  for ((i=0; i<${#ver1[@]}; i++)); do
+    if [[ -z "${ver2[i]}" ]]; then
+      # fill empty fields in ver2 with zeros
+      ver2[i]=0
+    fi
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      echo 1
+      return
+    fi
+    if ((10#${ver1[i]} < 10#${ver2[i]})); then
+      echo -1
+      return
+    fi
+  done
+  echo 0
+}


### PR DESCRIPTION
* AppVeyor build with CMake 3.0.0 to test CMake project / modules with the least supported CMake version
* Detection of CMake version even if CMake is not installed