### PR TITLE
Migrated CI builds using CMake 3.15.2 to CMake 3.15.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.15.2
+      CMAKE_VERSION: 3.15.3
       BOOST_VERSION: 1.71.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.11.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     # GCC 9, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc9-boost170-qt5
         apt:
@@ -70,13 +70,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc9-boost170-qt5
     # GCC 8, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc8-boost170-qt5
         apt:
@@ -92,13 +92,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc8-boost170-qt5
     # GCC 7, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost170-qt5
         apt:
@@ -114,13 +114,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost170-qt5
     # Clang 8.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang80-boost170-qt5
         apt:
@@ -138,13 +138,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang80-boost170-qt5
     # Clang 7.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang70-boost170-qt5
         apt:
@@ -162,13 +162,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang70-boost170-qt5
     # Clang 6.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang60-boost170-qt5
         apt:
@@ -186,13 +186,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang60-boost170-qt5
     # Clang 5.0, Boost 1.68.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang50-boost168-qt5
         apt:
@@ -210,7 +210,7 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost168-qt5
     # MacOS, Clang Apple LLVM version 10.0.1, Boost 1.69.0, Qt 5.x
@@ -233,7 +233,7 @@ matrix:
     # GCC 7, Boost 1.68.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost168-qt5
         apt:
@@ -249,7 +249,7 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.2 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost168-qt5
     # GCC 7, Boost 1.55.0, Qt 5.x


### PR DESCRIPTION
Migrated CI builds using CMake 3.15.2 to CMake 3.15.3 for better support of Boost 1.71.0