### PR TITLE
Support of Boost 1.73.0 and 1.74.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,8 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.17.2
-      BOOST_VERSION: 1.73.0
+      CMAKE_VERSION: 3.18.1
+      BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.11.3
       QT_LINKAGE: shared
@@ -56,15 +56,15 @@ environment:
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.2
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.17.2
-      BOOST_VERSION: 1.73.0
+      CMAKE_VERSION: 3.18.1
+      BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
     - APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.1
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.17.2
-      BOOST_VERSION: 1.73.0
+      CMAKE_VERSION: 3.18.1
+      BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.13.2
       QT_LINKAGE: shared
@@ -145,8 +145,8 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.17.2
-      BOOST_VERSION: 1.73.0
+      CMAKE_VERSION: 3.18.1
+      BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.7
       QT_LINKAGE: static

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.18.1
+      CMAKE_VERSION: 3.18.2
       BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.11.3
@@ -56,14 +56,14 @@ environment:
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.2
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.18.1
+      CMAKE_VERSION: 3.18.2
       BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
     - APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.1
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.18.1
+      CMAKE_VERSION: 3.18.2
       BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.13.2
@@ -145,7 +145,7 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.18.1
+      CMAKE_VERSION: 3.18.2
       BOOST_VERSION: 1.74.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.7

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,8 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.16.2
-      BOOST_VERSION: 1.72.0
+      CMAKE_VERSION: 3.17.2
+      BOOST_VERSION: 1.73.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.11.3
       QT_LINKAGE: shared
@@ -56,15 +56,15 @@ environment:
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.2
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.16.3
-      BOOST_VERSION: 1.72.0
+      CMAKE_VERSION: 3.17.2
+      BOOST_VERSION: 1.73.0
       BOOST_LINKAGE: static
     - APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       TOOLCHAIN: msvc
       MSVC_VERSION: 14.1
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.16.3
-      BOOST_VERSION: 1.72.0
+      CMAKE_VERSION: 3.17.2
+      BOOST_VERSION: 1.73.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.13.2
       QT_LINKAGE: shared
@@ -90,7 +90,7 @@ environment:
       MINGW_RT_VERSION: 5
       MINGW_REVISION: 0
       RUNTIME_LINKAGE: shared
-      CMAKE_VERSION: 3.16.3
+      CMAKE_VERSION: 3.17.2
       BOOST_VERSION: 1.72.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.13.2
@@ -145,8 +145,8 @@ environment:
     - TOOLCHAIN: msvc
       MSVC_VERSION: 14.0
       RUNTIME_LINKAGE: static
-      CMAKE_VERSION: 3.16.2
-      BOOST_VERSION: 1.72.0
+      CMAKE_VERSION: 3.17.2
+      BOOST_VERSION: 1.73.0
       BOOST_LINKAGE: static
       QT_VERSION: 5.7
       QT_LINKAGE: static

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     # Default GCC, Boost 1.55.0, Qt 5.x. Used for collecting information about test coverage.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc CXX_COMPILER=g++ BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG COVERAGE_BUILD_CANDIDATE=1
+      env: C_COMPILER=gcc CXX_COMPILER=g++ BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG COVERAGE_BUILD_CANDIDATE=1
       compiler: gcc
       addons:
         apt:
@@ -54,7 +54,7 @@ matrix:
     # GCC 10, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc10-boost174-qt5
         apt:
@@ -72,13 +72,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc10-boost174-qt5
     # GCC 9, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc9-boost174-qt5
         apt:
@@ -94,13 +94,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc9-boost174-qt5
     # GCC 8, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc8-boost170-qt5
         apt:
@@ -116,13 +116,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-8 CXX_COMPILER=g++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc8-boost170-qt5
     # GCC 7, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost170-qt5
         apt:
@@ -138,13 +138,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost170-qt5
     # Clang 10.0, Boost 1.74.0, Qt 5.x
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang10-boost174-qt5
         apt:
@@ -161,13 +161,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang10-boost174-qt5
     # Clang 9.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-9 CXX_COMPILER=clang++-9 CMAKE_VERSION=3.16.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-9 CXX_COMPILER=clang++-9 CMAKE_VERSION=3.16.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang90-boost170-qt5
         apt:
@@ -184,13 +184,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-9 CXX_COMPILER=clang++-9 CMAKE_VERSION=3.16.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-9 CXX_COMPILER=clang++-9 CMAKE_VERSION=3.16.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang90-boost170-qt5
     # Clang 8.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang80-boost170-qt5
         apt:
@@ -208,13 +208,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-8 CXX_COMPILER=clang++-8 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang80-boost170-qt5
     # Clang 7.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang70-boost170-qt5
         apt:
@@ -232,13 +232,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-7 CXX_COMPILER=clang++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang70-boost170-qt5
     # Clang 6.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang60-boost170-qt5
         apt:
@@ -256,13 +256,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang60-boost170-qt5
     # Clang 5.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang50-boost170-qt5
         apt:
@@ -280,13 +280,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost170-qt5
     # MacOS, Clang Apple LLVM version 11.3, Boost 1.73.0, Qt 5.x
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &homebrew-boost173-qt5
         homebrew:
@@ -298,13 +298,13 @@ matrix:
           update: true
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *homebrew-boost173-qt5
     # GCC 7, Boost 1.68.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost168-qt5
         apt:
@@ -320,13 +320,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost168-qt5
     # GCC 7, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost155-qt5
         apt:
@@ -340,13 +340,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost155-qt5
     # GCC 6, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc6-boost155-qt5
         apt:
@@ -360,13 +360,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc6-boost155-qt5
     # GCC 5, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc5-boost155-qt5
         apt:
@@ -380,13 +380,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc5-boost155-qt5
     # GCC 4.9, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc49-boost155-qt5
         apt:
@@ -400,13 +400,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc49-boost155-qt5
     # GCC 4.8, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc48-boost155-qt5
         apt:
@@ -420,13 +420,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc48-boost155-qt5
     # GCC 4.6, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc46-boost155-qt5
         apt:
@@ -440,13 +440,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc46-boost155-qt5
     # Clang 4.0, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang40-boost155-qt5
         apt:
@@ -464,13 +464,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang40-boost155-qt5
     # Clang 3.9, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang39-boost155-qt5
         apt:
@@ -488,13 +488,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang39-boost155-qt5
     # Clang 3.6, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang36-boost155-qt5
         apt:
@@ -512,13 +512,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang36-boost155-qt5
     # Clang 3.7, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang37-boost155-qt5
         apt:
@@ -536,13 +536,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang37-boost155-qt5
     # Clang 3.8, Boost 1.55.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang38-boost155-qt5
         apt:
@@ -560,13 +560,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang38-boost155-qt5
     # GCC 7, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc7-boost155-qt4
         apt:
@@ -580,13 +580,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-7 CXX_COMPILER=g++-7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost155-qt4
     # GCC 6, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc6-boost155-qt4
         apt:
@@ -600,13 +600,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc6-boost155-qt4
     # GCC 5, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc5-boost155-qt4
         apt:
@@ -620,13 +620,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc5-boost155-qt4
     # GCC 4.9, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc49-boost155-qt4
         apt:
@@ -640,13 +640,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc49-boost155-qt4
     # GCC 4.8, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc48-boost155-qt4
         apt:
@@ -660,13 +660,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc48-boost155-qt4
     # GCC 4.6, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc46-boost155-qt4
         apt:
@@ -680,13 +680,13 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-4.6 CXX_COMPILER=g++-4.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc46-boost155-qt4
     # Clang 5.0, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang50-boost155-qt4
         apt:
@@ -699,13 +699,13 @@ matrix:
           sources: *llvm50-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost155-qt4
     # Clang 4.0, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang40-boost155-qt4
         apt:
@@ -718,13 +718,13 @@ matrix:
           sources: *llvm40-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang40-boost155-qt4
     # Clang 3.9, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang39-boost155-qt4
         apt:
@@ -737,13 +737,13 @@ matrix:
           sources: *llvm39-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.9 CXX_COMPILER=clang++-3.9 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang39-boost155-qt4
     # Clang 3.6, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang36-boost155-qt4
         apt:
@@ -756,13 +756,13 @@ matrix:
           sources: *llvm36-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang36-boost155-qt4
     # Clang 3.7, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang37-boost155-qt4
         apt:
@@ -775,13 +775,13 @@ matrix:
           sources: *llvm37-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang37-boost155-qt4
     # Clang 3.8, Boost 1.55.0, Qt 4.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang38-boost155-qt4
         apt:
@@ -794,7 +794,7 @@ matrix:
           sources: *llvm38-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 BOOST_VERSION=1.55.0 QT_MAJOR_VERSION=4 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang38-boost155-qt4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,24 +235,24 @@ matrix:
       env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost168-qt5
-    # MacOS, Clang Apple LLVM version 11.3, Boost 1.71.0, Qt 5.x
+    # MacOS, Clang Apple LLVM version 11.3, Boost 1.60.0, Qt 5.x
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.71.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.60.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
-      addons: &homebrew-boost171-qt5
+      addons: &homebrew-boost160-qt5
         homebrew:
           packages:
             - gnu-sed
             - cmake
-            - boost
+            - boost@1.60
             - qt5
           update: true
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.71.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.60.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
-      addons: *homebrew-boost171-qt5
+      addons: *homebrew-boost160-qt5
     # GCC 7, Boost 1.68.0, Qt 5.x.
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,24 +235,24 @@ matrix:
       env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost168-qt5
-    # MacOS, Clang Apple LLVM version 11.3, Boost 1.60.0, Qt 5.x
+    # MacOS, Clang Apple LLVM version 11.3, Boost 1.72.0, Qt 5.x
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.60.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
-      addons: &homebrew-boost160-qt5
+      addons: &homebrew-boost172-qt5
         homebrew:
           packages:
             - gnu-sed
             - cmake
-            - boost@1.60
+            - boost@1.72
             - qt5
           update: true
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.60.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
-      addons: *homebrew-boost160-qt5
+      addons: *homebrew-boost172-qt5
     # GCC 7, Boost 1.68.0, Qt 5.x.
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,12 @@ matrix:
             - ubuntu-toolchain-r-test
             - boost-latest
             - sourceline: 'ppa:mhier/libboost-latest'
-    # GCC 10, Boost 1.72.0, Qt 5.x.
+    # GCC 10, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.17.2 BOOST_VERSION=1.65.1 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
-      addons: &apt-gcc10-boost165-qt5
+      addons: &apt-gcc10-boost174-qt5
         apt:
           packages:
             - cmake
@@ -65,21 +65,22 @@ matrix:
             - g++-10
             - curl
             - ca-certificates
-            - libboost-all-dev
+            - libboost1.74-dev
             - qtbase5-dev
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.17.2 BOOST_VERSION=1.65.1 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
-      addons: *apt-gcc10-boost165-qt5
-    # GCC 9, Boost 1.72.0, Qt 5.x.
+      addons: *apt-gcc10-boost174-qt5
+    # GCC 9, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.16.2 BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
-      addons: &apt-gcc9-qt5
+      addons: &apt-gcc9-boost174-qt5
         apt:
           packages:
             - cmake
@@ -88,13 +89,14 @@ matrix:
             - g++-9
             - curl
             - ca-certificates
+            - libboost1.74-dev
             - qtbase5-dev
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.16.2 BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
-      addons: *apt-gcc9-qt5
+      addons: *apt-gcc9-boost174-qt5
     # GCC 8, Boost 1.70.0, Qt 5.x.
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -283,12 +283,12 @@ matrix:
       env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang50-boost170-qt5
-    # MacOS, Clang Apple LLVM version 11.3, Boost 1.72.0, Qt 5.x
+    # MacOS, Clang Apple LLVM version 11.3, Boost 1.73.0, Qt 5.x
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
-      addons: &homebrew-boost172-qt5
+      addons: &homebrew-boost173-qt5
         homebrew:
           packages:
             - gnu-sed
@@ -298,9 +298,9 @@ matrix:
           update: true
     - os: osx
       osx_image: xcode11.3
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.72.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang CXX_COMPILER=clang++ BOOST_VERSION=1.73.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
-      addons: *homebrew-boost172-qt5
+      addons: *homebrew-boost173-qt5
     # GCC 7, Boost 1.68.0, Qt 5.x.
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -259,12 +259,12 @@ matrix:
       env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang60-boost170-qt5
-    # Clang 5.0, Boost 1.68.0, Qt 5.x
+    # Clang 5.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
-      addons: &apt-clang50-boost168-qt5
+      addons: &apt-clang50-boost170-qt5
         apt:
           packages:
             - cmake
@@ -280,9 +280,9 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: trusty
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.68.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
-      addons: *apt-clang50-boost168-qt5
+      addons: *apt-clang50-boost170-qt5
     # MacOS, Clang Apple LLVM version 11.3, Boost 1.72.0, Qt 5.x
     - os: osx
       osx_image: xcode11.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     # GCC 10, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: bionic
-      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc10-boost174-qt5
         apt:
@@ -72,13 +72,13 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-10 CXX_COMPILER=g++-10 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc10-boost174-qt5
     # GCC 9, Boost 1.74.0, Qt 5.x.
     - os: linux
       dist: trusty
-      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: gcc
       addons: &apt-gcc9-boost174-qt5
         apt:
@@ -94,7 +94,7 @@ matrix:
           sources: *gcc-package-sources
     - os: linux
       dist: trusty
-      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=gcc-9 CXX_COMPILER=g++-9 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc9-boost174-qt5
     # GCC 8, Boost 1.70.0, Qt 5.x.
@@ -144,7 +144,7 @@ matrix:
     # Clang 10.0, Boost 1.74.0, Qt 5.x
     - os: linux
       dist: bionic
-      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
       addons: &apt-clang10-boost174-qt5
         apt:
@@ -161,7 +161,7 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.2 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
       addons: *apt-clang10-boost174-qt5
     # Clang 9.0, Boost 1.70.0, Qt 5.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,28 +141,29 @@ matrix:
       env: CXX_COMPILER_FAMILY=gcc C_COMPILER=gcc-7 CXX_COMPILER=g++-7 CMAKE_VERSION=3.15.3 BOOST_VERSION=1.70.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: gcc
       addons: *apt-gcc7-boost170-qt5
-    # Clang 10.0, Boost 1.70.0, Qt 5.x
+    # Clang 10.0, Boost 1.74.0, Qt 5.x
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.17.2 BOOST_VERSION=1.65.1 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=RELEASE
       compiler: clang
-      addons: &apt-clang10-boost165-qt5
+      addons: &apt-clang10-boost174-qt5
         apt:
           packages:
             - cmake
             - cmake-data
             - clang-10
-            - libboost-all-dev
+            - libboost1.74-dev
             - qtbase5-dev
           sources:
             - ubuntu-toolchain-r-test
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'ppa:mhier/libboost-latest'
     - os: linux
       dist: bionic
-      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.17.2 BOOST_VERSION=1.65.1 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
+      env: CXX_COMPILER_FAMILY=clang C_COMPILER=clang-10 CXX_COMPILER=clang++-10 CMAKE_VERSION=3.18.1 BOOST_VERSION=1.74.0 QT_MAJOR_VERSION=5 BUILD_TYPE=DEBUG
       compiler: clang
-      addons: *apt-clang10-boost165-qt5
+      addons: *apt-clang10-boost174-qt5
     # Clang 9.0, Boost 1.70.0, Qt 5.x
     - os: linux
       dist: trusty

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Refer to [docker/builder/README.md](docker/builder/README.md) for instruction on
 
 * [Boost](https://www.boost.org)
 
-  1.47+, the latest tested version is 1.72
+  1.47+, the latest tested version is 1.74
 
 * [Google Test](https://github.com/google/googletest) 
 

--- a/docker/builder/alpine/Dockerfile
+++ b/docker/builder/alpine/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:20191219
+FROM alpine:20200319
 
 LABEL name="abrarov/asio-samples-builder-alpine" \
     description="Builder of Asio samples project on Alpine Linux"

--- a/docker/ma_echo_server/alpine/Dockerfile
+++ b/docker/ma_echo_server/alpine/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:20200319
+FROM alpine:3.12.0
 
 LABEL name="abrarov/tcp-echo" \
     description="TCP echo server from Asio samples project" \

--- a/docker/ma_echo_server/alpine/Dockerfile
+++ b/docker/ma_echo_server/alpine/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:20191219
+FROM alpine:20200319
 
 LABEL name="abrarov/tcp-echo" \
     description="TCP echo server from Asio samples project" \

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:20.04 AS build
 ARG MA_REVISION="master"
 ARG CMAKE_VERSION="3.18.2"
 ARG BOOST_VERSION="1.74.0"
-ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
+ARG BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost"
 
 ENV TZ=Europe/Moscow
 
@@ -36,7 +36,7 @@ RUN mkdir -p /opt && \
     mv -f "/opt/cmake-${CMAKE_VERSION}-Linux-x86_64" /opt/cmake
 
 RUN mkdir -p "${DEPENDENCIES_DIR}" && \
-    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d').tar.gz" && \
+    boost_archive_url="${BOOST_URL}/${BOOST_VERSION}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d').tar.gz" && \
     echo "Downloading Boost from ${boost_archive_url}" && \
     curl --connect-timeout 300 \
       --max-time 1800 \

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -8,7 +8,7 @@
 FROM debian:10-slim AS build
 
 ARG MA_REVISION="master"
-ARG CMAKE_VERSION="3.16.3"
+ARG CMAKE_VERSION="3.18.1"
 
 RUN apt-get update && \
     apt-get install -y \

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /opt && \
     mv -f "/opt/cmake-${CMAKE_VERSION}-Linux-x86_64" /opt/cmake
 
 RUN mkdir -p "${DEPENDENCIES_DIR}" && \
-    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion).tar.gz" && \
+    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d').tar.gz" && \
     echo "Downloading Boost from ${boost_archive_url}" && \
     curl --connect-timeout 300 \
       --max-time 1800 \
@@ -52,7 +52,7 @@ RUN mkdir -p "${SOURCE_DIR}" && \
 
 RUN mkdir -p "${BUILD_DIR}" && \
     cd "${BUILD_DIR}" && \
-    boost_dir="${DEPENDENCIES_DIR}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion)" && \
+    boost_dir="${DEPENDENCIES_DIR}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')" && \
     cmake \
       -D CMAKE_SKIP_BUILD_RPATH=ON \
       -D CMAKE_BUILD_TYPE=RELEASE \

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -8,7 +8,7 @@
 FROM ubuntu:20.04 AS build
 
 ARG MA_REVISION="master"
-ARG CMAKE_VERSION="3.18.1"
+ARG CMAKE_VERSION="3.18.2"
 ARG BOOST_VERSION="1.74.0"
 ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
 

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -5,29 +5,45 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM debian:10-slim AS build
+FROM ubuntu:20.04 AS build
 
 ARG MA_REVISION="master"
 ARG CMAKE_VERSION="3.18.1"
+ARG BOOST_VERSION="1.74.0"
+ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
 
-RUN apt-get update && \
+ENV TZ=Europe/Moscow
+
+RUN ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime && \
+    echo "${TZ}" > /etc/timezone && \
+    apt-get update && \
     apt-get install -y \
       curl \
       git \
       g++ \
       make \
-      libstdc++-8-dev \
-      libboost-all-dev
+      libstdc++-9-dev
 
 ENV PATH="/opt/cmake/bin:${PATH}" \
     SOURCE_DIR="/tmp/asio_samples/src" \
-    BUILD_DIR="/tmp/asio_samples/build"
+    BUILD_DIR="/tmp/asio_samples/build" \
+    DEPENDENCIES_DIR="/tmp/asio_samples/dependency"
 
 RUN mkdir -p /opt && \
     cmake_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION} from ${cmake_url}" && \
     curl -jksSL "${cmake_url}" | tar -xzf - -C /opt && \
     mv -f "/opt/cmake-${CMAKE_VERSION}-Linux-x86_64" /opt/cmake
+
+RUN mkdir -p "${DEPENDENCIES_DIR}" && \
+    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion).tar.gz" && \
+    echo "Downloading Boost from ${boost_archive_url}" && \
+    curl --connect-timeout 300 \
+      --max-time 1800 \
+      --retry 10 \
+      --retry-delay 10 \
+      -jksSL \
+      "${boost_archive_url}" | tar -xz -C "${DEPENDENCIES_DIR}"
 
 RUN mkdir -p "${SOURCE_DIR}" && \
     git clone https://github.com/mabrarov/asio_samples.git "${SOURCE_DIR}" && \
@@ -36,10 +52,14 @@ RUN mkdir -p "${SOURCE_DIR}" && \
 
 RUN mkdir -p "${BUILD_DIR}" && \
     cd "${BUILD_DIR}" && \
+    boost_dir="${DEPENDENCIES_DIR}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion)" && \
     cmake \
       -D CMAKE_SKIP_BUILD_RPATH=ON \
       -D CMAKE_BUILD_TYPE=RELEASE \
       -D Boost_USE_STATIC_LIBS=ON \
+      -D Boost_NO_SYSTEM_PATHS=ON \
+      -D BOOST_INCLUDEDIR="${boost_dir}/include" \
+      -D BOOST_LIBRARYDIR="${boost_dir}/lib" \
       -D MA_TESTS=OFF \
       -D MA_QT=OFF \
       "${SOURCE_DIR}" && \

--- a/docker/ma_echo_server/nanoserver/Dockerfile
+++ b/docker/ma_echo_server/nanoserver/Dockerfile
@@ -9,7 +9,7 @@ FROM abrarov/msvc-2019:2.9.0 AS build
 
 ARG MA_REVISION=master
 
-ENV CMAKE_VERSION="3.18.1" \
+ENV CMAKE_VERSION="3.18.2" \
     BOOST_VERSION="1.74.0" \
     BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost" \
     SOURCE_DIR="C:\asio_samples" \

--- a/docker/ma_echo_server/nanoserver/Dockerfile
+++ b/docker/ma_echo_server/nanoserver/Dockerfile
@@ -5,12 +5,12 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM abrarov/msvc-2019:2.8.0 AS build
+FROM abrarov/msvc-2019:2.9.0 AS build
 
 ARG MA_REVISION=master
 
-ENV CMAKE_VERSION="3.16.3" \
-    BOOST_VERSION="1.72.0" \
+ENV CMAKE_VERSION="3.18.1" \
+    BOOST_VERSION="1.74.0" \
     BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost" \
     SOURCE_DIR="C:\asio_samples" \
     BUILD_DIR="C:\build" \

--- a/docker/ma_echo_server/static/Dockerfile
+++ b/docker/ma_echo_server/static/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:20191219 AS build
+FROM alpine:20200319 AS build
 
 ARG MA_REVISION="master"
 ARG BOOST_VERSION="1.72.0"

--- a/docker/ma_echo_server/static/Dockerfile
+++ b/docker/ma_echo_server/static/Dockerfile
@@ -8,7 +8,7 @@
 FROM alpine:3.12.0 AS build
 
 ARG MA_REVISION="master"
-ARG BOOST_VERSION="1.72.0"
+ARG BOOST_VERSION="1.74.0"
 ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
 
 RUN apk add --no-cache \
@@ -27,7 +27,7 @@ ENV SOURCE_DIR="/tmp/asio_samples/src" \
     DEPENDENCIES_DIR="/tmp/asio_samples/dependency"
 
 RUN mkdir -p "${DEPENDENCIES_DIR}" && \
-    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc9.2-musl-static-runtime.tar.gz" && \
+    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')-musl-static-runtime.tar.gz" && \
     echo "Downloading Boost from ${boost_archive_url}" && \
     curl --connect-timeout 300 \
       --max-time 1800 \
@@ -43,7 +43,7 @@ RUN mkdir -p "${SOURCE_DIR}" && \
 
 RUN mkdir -p "${BUILD_DIR}" && \
     cd "${BUILD_DIR}" && \
-    boost_dir="${DEPENDENCIES_DIR}/boost-${BOOST_VERSION}-x64-gcc9.2" && \
+    boost_dir="${DEPENDENCIES_DIR}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')-musl" && \
     cmake \
       -D CMAKE_SKIP_BUILD_RPATH=ON \
       -D CMAKE_BUILD_TYPE=RELEASE \

--- a/docker/ma_echo_server/static/Dockerfile
+++ b/docker/ma_echo_server/static/Dockerfile
@@ -9,7 +9,7 @@ FROM alpine:3.12.0 AS build
 
 ARG MA_REVISION="master"
 ARG BOOST_VERSION="1.74.0"
-ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
+ARG BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost"
 
 RUN apk add --no-cache \
       libstdc++ \
@@ -27,7 +27,7 @@ ENV SOURCE_DIR="/tmp/asio_samples/src" \
     DEPENDENCIES_DIR="/tmp/asio_samples/dependency"
 
 RUN mkdir -p "${DEPENDENCIES_DIR}" && \
-    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')-musl-static-runtime.tar.gz" && \
+    boost_archive_url="${BOOST_URL}/${BOOST_VERSION}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')-musl-static-runtime.tar.gz" && \
     echo "Downloading Boost from ${boost_archive_url}" && \
     curl --connect-timeout 300 \
       --max-time 1800 \

--- a/docker/ma_echo_server/static/Dockerfile
+++ b/docker/ma_echo_server/static/Dockerfile
@@ -5,11 +5,11 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:20200319 AS build
+FROM alpine:3.12.0 AS build
 
 ARG MA_REVISION="master"
 ARG BOOST_VERSION="1.72.0"
-ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file?file_path=boost%2F1.72.0%2Fboost-1.72.0-x64-gcc9.2-musl-static-runtime.tar.gz"
+ARG BOOST_URL="https://bintray.com/mabrarov/generic/download_file"
 
 RUN apk add --no-cache \
       libstdc++ \
@@ -26,19 +26,20 @@ ENV SOURCE_DIR="/tmp/asio_samples/src" \
     BUILD_DIR="/tmp/asio_samples/build" \
     DEPENDENCIES_DIR="/tmp/asio_samples/dependency"
 
-RUN mkdir -p "${SOURCE_DIR}" && \
-    git clone https://github.com/mabrarov/asio_samples.git "${SOURCE_DIR}" && \
-    cd "${SOURCE_DIR}" && \
-    git checkout "${MA_REVISION}"
-
 RUN mkdir -p "${DEPENDENCIES_DIR}" && \
-    echo "Downloading Boost from ${BOOST_URL}" && \
+    boost_archive_url="${BOOST_URL}?file_path=boost%2F${BOOST_VERSION}%2Fboost-${BOOST_VERSION}-x64-gcc9.2-musl-static-runtime.tar.gz" && \
+    echo "Downloading Boost from ${boost_archive_url}" && \
     curl --connect-timeout 300 \
       --max-time 1800 \
       --retry 10 \
       --retry-delay 10 \
       -jksSL \
-      "${BOOST_URL}" | tar -xz -C "${DEPENDENCIES_DIR}"
+      "${boost_archive_url}" | tar -xz -C "${DEPENDENCIES_DIR}"
+
+RUN mkdir -p "${SOURCE_DIR}" && \
+    git clone https://github.com/mabrarov/asio_samples.git "${SOURCE_DIR}" && \
+    cd "${SOURCE_DIR}" && \
+    git checkout "${MA_REVISION}"
 
 RUN mkdir -p "${BUILD_DIR}" && \
     cd "${BUILD_DIR}" && \

--- a/examples/asio_multicast_receiver/CMakeLists.txt
+++ b/examples/asio_multicast_receiver/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND cxx_sources
 
 list(APPEND cxx_private_libraries
     ma_boost_header_only
+    ma_compat
     ma_boost_asio
     ma_coverage)
 

--- a/examples/asio_multicast_receiver/src/receiver.cpp
+++ b/examples/asio_multicast_receiver/src/receiver.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
-#include "boost/bind.hpp"
+#include <ma/detail/functional.hpp>
 
 class receiver
 {
@@ -36,9 +36,8 @@ public:
 
     socket_.async_receive_from(
         boost::asio::buffer(data_, max_length), sender_endpoint_,
-        boost::bind(&receiver::handle_receive_from, this,
-          boost::asio::placeholders::error,
-          boost::asio::placeholders::bytes_transferred));
+        ma::detail::bind(&receiver::handle_receive_from, this,
+          ma::detail::placeholders::_1, ma::detail::placeholders::_2));
   }
 
   void handle_receive_from(const boost::system::error_code& error,
@@ -51,9 +50,8 @@ public:
 
       socket_.async_receive_from(
           boost::asio::buffer(data_, max_length), sender_endpoint_,
-          boost::bind(&receiver::handle_receive_from, this,
-            boost::asio::placeholders::error,
-            boost::asio::placeholders::bytes_transferred));
+          ma::detail::bind(&receiver::handle_receive_from, this,
+            ma::detail::placeholders::_1, ma::detail::placeholders::_2));
     }
   }
 

--- a/examples/asio_multicast_sender/CMakeLists.txt
+++ b/examples/asio_multicast_sender/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND cxx_private_libraries
     ma_boost_header_only
     ma_boost_asio
     ma_boost_date_time
+    ma_compat
     ma_coverage)
 
 add_executable(${PROJECT_NAME}

--- a/examples/asio_multicast_sender/src/sender.cpp
+++ b/examples/asio_multicast_sender/src/sender.cpp
@@ -13,8 +13,8 @@
 #include <string>
 #include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
-#include "boost/bind.hpp"
-#include "boost/date_time/posix_time/posix_time_types.hpp"
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <ma/detail/functional.hpp>
 
 const int max_message_count = 10;
 
@@ -35,8 +35,8 @@ public:
 
     socket_.async_send_to(
         boost::asio::buffer(message_), endpoint_,
-        boost::bind(&sender::handle_send_to, this,
-          boost::asio::placeholders::error));
+        ma::detail::bind(&sender::handle_send_to, this,
+          ma::detail::placeholders::_1));
   }
 
   void handle_send_to(const boost::system::error_code& error)
@@ -45,8 +45,8 @@ public:
     {
       timer_.expires_from_now(boost::posix_time::seconds(1));
       timer_.async_wait(
-          boost::bind(&sender::handle_timeout, this,
-            boost::asio::placeholders::error));
+          ma::detail::bind(&sender::handle_timeout, this,
+            ma::detail::placeholders::_1));
     }
   }
 
@@ -60,8 +60,8 @@ public:
 
       socket_.async_send_to(
           boost::asio::buffer(message_), endpoint_,
-          boost::bind(&sender::handle_send_to, this,
-            boost::asio::placeholders::error));
+          ma::detail::bind(&sender::handle_send_to, this,
+            ma::detail::placeholders::_1));
     }
   }
 

--- a/libs/ma_windows_console_signal/src/console_signal_service.cpp
+++ b/libs/ma_windows_console_signal/src/console_signal_service.cpp
@@ -155,18 +155,11 @@ BOOL WINAPI console_signal_service_base::system_service::windows_ctrl_handler(
   {
   case CTRL_C_EVENT:
   case CTRL_BREAK_EVENT:
-    if (instance->deliver_signal(SIGINT))
-    {
-      return TRUE;
-    }
-    return FALSE;
+    return instance->deliver_signal(SIGINT) ? TRUE : FALSE;
   case CTRL_CLOSE_EVENT:
   case CTRL_LOGOFF_EVENT:
   case CTRL_SHUTDOWN_EVENT:
-    if (instance->deliver_signal(SIGTERM))
-    {
-      return TRUE;
-    }
+    return instance->deliver_signal(SIGTERM) ? TRUE : FALSE;
   default:
     return FALSE;
   }

--- a/scripts/appveyor/install.ps1
+++ b/scripts/appveyor/install.ps1
@@ -321,7 +321,8 @@ if (Test-Path env:BOOST_VERSION) {
     "msvc" {
       switch (${env:MSVC_VERSION}) {
         "14.2" {
-          $pre_installed_boost = ${env:BOOST_VERSION} -eq "1.71.0"
+          $pre_installed_boost = (${env:BOOST_VERSION} -eq "1.71.0") `
+            -or (${env:BOOST_VERSION} -eq "1.73.0") `
         }
         "14.1" {
           $pre_installed_boost = (${env:BOOST_VERSION} -eq "1.69.0") `
@@ -335,7 +336,9 @@ if (Test-Path env:BOOST_VERSION) {
             -or (${env:BOOST_VERSION} -eq "1.67.0") `
             -or (${env:BOOST_VERSION} -eq "1.66.0") `
             -or (${env:BOOST_VERSION} -eq "1.65.1") `
-            -or (${env:BOOST_VERSION} -eq "1.63.0")
+            -or (${env:BOOST_VERSION} -eq "1.63.0") `
+            -or (${env:BOOST_VERSION} -eq "1.62.0") `
+            -or (${env:BOOST_VERSION} -eq "1.60.0")
         }
         "12.0" {
           $pre_installed_boost = (${env:BOOST_VERSION} -eq "1.58.0")
@@ -471,17 +474,21 @@ if (Test-Path env:QT_VERSION) {
     switch (${env:TOOLCHAIN}) {
       "msvc" {
         switch (${env:MSVC_VERSION}) {
+          "14.2" {
+            $pre_installed_qt = ${env:QT_VERSION} -eq "5.15.0"
+          }
           "14.1" {
             $pre_installed_qt = (${env:QT_VERSION} -eq "5.13.2") `
               -or (${env:QT_VERSION} -eq "5.12.6") `
               -or ((${env:QT_VERSION} -eq "5.10.1") -and (${env:PLATFORM} -eq "x64"))
           }
           "14.0" {
-            $pre_installed_qt = ((${env:QT_VERSION} -eq "5.13.0") -and (${env:PLATFORM} -eq "x64")) `
-              -or ((${env:QT_VERSION} -eq "5.12.2") -and (${env:PLATFORM} -eq "x64")) `
+            $pre_installed_qt = ((${env:QT_VERSION} -eq "5.13.2") -and (${env:PLATFORM} -eq "x64")) `
+              -or ((${env:QT_VERSION} -eq "5.12.6") -and (${env:PLATFORM} -eq "x64")) `
               -or (${env:QT_VERSION} -eq "5.11.3") `
               -or (${env:QT_VERSION} -eq "5.10.1") `
-              -or (${env:QT_VERSION} -eq "5.9.5") `
+              -or (${env:QT_VERSION} -eq "5.9.9") `
+              -or ((${env:QT_VERSION} -eq "5.7.0") -and (${env:PLATFORM} -eq "x86")) `
               -or (${env:QT_VERSION} -eq "5.6.3")
           }
           "12.0" {

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -50,9 +50,9 @@ fi
 ctest --build-config "${BUILD_TYPE}" --verbose
 
 if [[ "${COVERAGE_BUILD}" -ne 0 ]]; then
-  echo "Caclulating coverage at ${BUILD_HOME}/lcov-test.info"
+  echo "Calculating coverage at ${BUILD_HOME}/lcov-test.info"
   lcov -c -d "${BUILD_HOME}" -o lcov-test.info --rc lcov_branch_coverage=1
-  echo "Caclulating coverage delta at ${BUILD_HOME}/lcov.info"
+  echo "Calculating coverage delta at ${BUILD_HOME}/lcov.info"
   lcov -a lcov-base.info -a lcov-test.info -o lcov.info --rc lcov_branch_coverage=1
   echo "Excluding 3rd party code from coverage data located at ${BUILD_HOME}/lcov.info"
   lcov -r lcov.info \

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -12,7 +12,8 @@ set -e
 # shellcheck source=travis_retry.sh
 source "${TRAVIS_BUILD_DIR}/scripts/travis/travis_retry.sh"
 
-codecov_flag="${TRAVIS_OS_NAME}__$(uname -r | sed -r 's/[[:space:]]|[\\\.\/:]/_/g')__${CXX_COMPILER_FAMILY}_$(${CXX_COMPILER} -dumpversion)__boost_${BOOST_VERSION}__qt_${QT_MAJOR_VERSION}"
+cxx_compiler_family="$(echo "${C_COMPILER:-gcc}" | sed -r 's/^(\w+)\-.*$/\1/;t;d')"
+codecov_flag="${TRAVIS_OS_NAME}__$(uname -r | sed -r 's/[[:space:]]|[\\\.\/:]/_/g')__${cxx_compiler_family}_$(${CXX_COMPILER} -dumpversion)__boost_${BOOST_VERSION}__qt_${QT_MAJOR_VERSION}"
 codecov_flag="${codecov_flag//[.-]/_}"
 
 echo "Preparing build dir at ${BUILD_HOME}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -16,6 +16,8 @@ if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
   export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:${PATH}"
 fi
 
+cxx_compiler_family="$(echo "${C_COMPILER:-gcc}" | sed -r 's/^(\w+)\-.*$/\1/;t;d')"
+
 detected_cmake_version=""
 if which cmake > /dev/null; then
   detected_cmake_version="$({ cmake --version 2> /dev/null || echo ""; } \
@@ -104,7 +106,11 @@ if [[ "${system_boost_home}" -eq 0 ]] && [[ -n "${BOOST_VERSION+x}" ]]; then
     echo "Chosen version of Boost: ${BOOST_VERSION} is not supported for OS: ${TRAVIS_OS_NAME}"
     exit 1
   fi
-  boost_archive_base_name="boost-${BOOST_VERSION}-x64-gcc4.8"
+  if ! [[ "${cxx_compiler_family}" = "gcc" ]]; then
+    echo "Chosen compiler: ${cxx_compiler_family} is not supported by available prebuilt Boost downloads"
+    exit 1
+  fi
+  boost_archive_base_name="boost-${BOOST_VERSION}-x64-${cxx_compiler_family}$(gcc -dumpversion)"
   export BOOST_HOME="${DEPENDENCIES_HOME}/${boost_archive_base_name}"
   if [[ ! -d "${BOOST_HOME}" ]]; then
     echo "Boost is absent for the chosen Boost version (${BOOST_VERSION}) at ${BOOST_HOME}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -110,7 +110,7 @@ if [[ "${system_boost_home}" -eq 0 ]] && [[ -n "${BOOST_VERSION+x}" ]]; then
     echo "Chosen compiler: ${cxx_compiler_family} is not supported by available prebuilt Boost downloads"
     exit 1
   fi
-  boost_archive_base_name="boost-${BOOST_VERSION}-x64-${cxx_compiler_family}$(gcc -dumpversion)"
+  boost_archive_base_name="boost-${BOOST_VERSION}-x64-${cxx_compiler_family}$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d')"
   export BOOST_HOME="${DEPENDENCIES_HOME}/${boost_archive_base_name}"
   if [[ ! -d "${BOOST_HOME}" ]]; then
     echo "Boost is absent for the chosen Boost version (${BOOST_VERSION}) at ${BOOST_HOME}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -77,14 +77,16 @@ elif [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
     || [[ "${BOOST_VERSION}" = "1.57.0" ]] \
     || [[ "${BOOST_VERSION}" = "1.59.0" ]] \
     || [[ "${BOOST_VERSION}" = "1.60.0" ]] \
-    || [[ "${BOOST_VERSION}" = "1.69.0" ]] \
-    || [[ "${BOOST_VERSION}" = "1.70.0" ]] \
-    || [[ "${BOOST_VERSION}" = "1.71.0" ]]; then
+    || [[ "${BOOST_VERSION}" = "1.72.0" ]]; then
     system_boost_home=1
   fi
 fi
 
 if [[ "${system_boost_home}" -eq 0 ]]; then
+  if ! [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
+    echo "Chosen version of Boost: ${BOOST_VERSION} is not supported for OS: ${TRAVIS_OS_NAME}"
+    exit 1
+  fi
   boost_archive_base_name="boost-${BOOST_VERSION}-x64-gcc4.8"
   export BOOST_HOME="${DEPENDENCIES_HOME}/${boost_archive_base_name}"
   if [[ ! -d "${BOOST_HOME}" ]]; then

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -73,7 +73,7 @@ if [[ -n "${BOOST_VERSION+x}" ]]; then
   system_boost_home=0
   if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
     dashed_boost_version="$(echo "${BOOST_VERSION}" | sed -r 's/([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)/\1.\2-\3/')"
-    for system_boost_version in $(dpkg -l | sed -r 's/^ii[[:space:]]+libboost.*\-dev(:[^[:space:]]+)*[[:space:]]+([^[:space:]]+)[[:space:]]+.*$/\2/;t;d'); do
+    for system_boost_version in $(dpkg -l | sed -r 's/^ii[[:space:]]+libboost[[:digit:]]+(\.[[:digit:]]+)*(\-all)?\-dev(:[^[:space:]]+)*[[:space:]]+([^[:space:]]+)[[:space:]]+.*$/\4/;t;d'); do
       echo "Detected Boost of ${system_boost_version} version"
       if echo "${system_boost_version}" | grep -F "${BOOST_VERSION}" > /dev/null; then
         system_boost_home=1

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -65,17 +65,16 @@ fi
 
 system_boost_home=0
 if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
-  if [[ "${TRAVIS_DIST}" = "trusty" ]]; then
-    if [[ "${BOOST_VERSION}" = "1.55.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.68.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.70.0" ]]; then
+  dashed_boost_version="$(echo "${BOOST_VERSION}" | sed -r 's/([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)/\1.\2-\3/')"
+  for system_boost_version in $(dpkg -l | sed -r 's/^ii[[:space:]]+libboost.*\-dev(:[^[:space:]]+)*[[:space:]]+([^[:space:]]+)[[:space:]]+.*$/\2/;t;d'); do
+    if echo "${system_boost_version}" | grep -F "${BOOST_VERSION}" &> /dev/null; then
       system_boost_home=1
-    fi
-  elif [[ "${TRAVIS_DIST}" = "bionic" ]]; then
-    if [[ "${BOOST_VERSION}" = "1.65.1" ]]; then
+      break
+    elif echo "${system_boost_version}" | grep -F "${dashed_boost_version}" &> /dev/null; then
       system_boost_home=1
+      break
     fi
-  fi
+  done
 elif [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
   if [[ "${BOOST_VERSION}" = "1.55.0" ]] \
     || [[ "${BOOST_VERSION}" = "1.57.0" ]] \

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -74,6 +74,7 @@ if [[ -n "${BOOST_VERSION+x}" ]]; then
   if [[ "${TRAVIS_OS_NAME}" = "linux" ]]; then
     dashed_boost_version="$(echo "${BOOST_VERSION}" | sed -r 's/([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)/\1.\2-\3/')"
     for system_boost_version in $(dpkg -l | sed -r 's/^ii[[:space:]]+libboost.*\-dev(:[^[:space:]]+)*[[:space:]]+([^[:space:]]+)[[:space:]]+.*$/\2/;t;d'); do
+      echo "Detected Boost of ${system_boost_version} version"
       if echo "${system_boost_version}" | grep -F "${BOOST_VERSION}" > /dev/null; then
         system_boost_home=1
         break
@@ -85,6 +86,7 @@ if [[ -n "${BOOST_VERSION+x}" ]]; then
   elif [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
     if brew list --versions boost > /dev/null; then
       for system_boost_version in $(brew info boost | sed -r 's/^boost:.*[[:space:]]+([[:digit:]]+[^[:space:]]*)[[:space:]]+.*$/\1/;t;d'); do
+        echo "Detected Boost of ${system_boost_version} version"
         if echo "${system_boost_version}" | grep -F "${BOOST_VERSION}" > /dev/null; then
           system_boost_home=1
           break

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -83,14 +83,13 @@ if [[ -n "${BOOST_VERSION+x}" ]]; then
       fi
     done
   elif [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
-    echo "Check if Boost Brew formula installed"
-    brew list boost && brew list --versions boost
-    if [[ "${BOOST_VERSION}" = "1.55.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.57.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.59.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.60.0" ]] \
-      || [[ "${BOOST_VERSION}" = "1.72.0" ]]; then
-      system_boost_home=1
+    if brew list --versions boost > /dev/null; then
+      for system_boost_version in $(brew info boost | sed -r 's/^boost:.*[[:space:]]+([[:digit:]]+[^[:space:]]*)[[:space:]]+.*$/\1/;t;d'); do
+        if echo "${system_boost_version}" | grep -F "${BOOST_VERSION}" > /dev/null; then
+          system_boost_home=1
+          break
+        fi
+      done
     fi
   else
     echo "Unsupported OS: ${TRAVIS_OS_NAME}"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -83,6 +83,8 @@ if [[ -n "${BOOST_VERSION+x}" ]]; then
       fi
     done
   elif [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
+    echo "Check if Boost Brew formula installed"
+    brew list boost && brew list --versions boost
     if [[ "${BOOST_VERSION}" = "1.55.0" ]] \
       || [[ "${BOOST_VERSION}" = "1.57.0" ]] \
       || [[ "${BOOST_VERSION}" = "1.59.0" ]] \


### PR DESCRIPTION
* Fixed detection of version of Boost installed via system package manager in CI scripts
* Migrated CI builds to Boost 1.74.0
* Fixed Boost deprecation warnings and build warnings