### PR TITLE
Travis CI and AppVeyor CI Codecov fixed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ environment:
   CURL_RETRY: 10
   CURL_RETRY_DELAY: 10
   PIP_RETRY: 10
-  CODECOV_VERSION: 2.0.15
+  CODECOV_VERSION: 2.1.7
 
   matrix:
     - TOOLCHAIN: msvc

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - CURL_RETRY: 10
     - CURL_RETRY_DELAY: 10
     - PIP_RETRY: 10
-    - CODECOV_VERSION: 2.0.15
+    - CODECOV_VERSION: 2.1.7
 
 before_install: source ./scripts/travis/before_install.sh
 


### PR DESCRIPTION
Migration of Travis CI and AppVeyor CI to the latest version of Codecov python to solve its issue #251 (codecov/codecov-python#251)