### PR TITLE
Distroless Debian 11 image

### DIFF
--- a/docker/builder/alpine/Dockerfile
+++ b/docker/builder/alpine/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:3.13.2
+FROM alpine:3.13.6
 
 LABEL name="abrarov/asio-samples-builder-alpine" \
     description="Builder of Asio samples project on Alpine Linux"
@@ -19,7 +19,7 @@ ENV PROJECT_DIR="/project" \
 
 ENTRYPOINT ["/app/start.sh"]
 
-RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+RUN echo 'http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
     apk add --no-cache \
       g++ \
       make \

--- a/docker/builder/centos/Dockerfile
+++ b/docker/builder/centos/Dockerfile
@@ -17,7 +17,7 @@ ENV PROJECT_DIR="/project" \
     MA_QT="ON" \
     MA_QT_MAJOR_VERSION="5" \
     MA_COVERAGE="OFF" \
-    CMAKE_VERSION="3.19.6" \
+    CMAKE_VERSION="3.21.3" \
     PATH="/opt/cmake/bin:${PATH}"
 
 ENTRYPOINT ["/app/start.sh"]

--- a/docker/builder/ubuntu/Dockerfile
+++ b/docker/builder/ubuntu/Dockerfile
@@ -17,7 +17,7 @@ ENV TZ="Europe/Moscow" \
     MA_QT="ON" \
     MA_QT_MAJOR_VERSION="5" \
     MA_COVERAGE="OFF" \
-    CMAKE_VERSION="3.19.6" \
+    CMAKE_VERSION="3.21.3" \
     PATH="/opt/cmake/bin:${PATH}"
 
 ENTRYPOINT ["/app/start.sh"]

--- a/docker/ma_echo_server/alpine/Dockerfile
+++ b/docker/ma_echo_server/alpine/Dockerfile
@@ -5,7 +5,7 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:3.13.5
+FROM alpine:3.13.6
 
 LABEL name="abrarov/tcp-echo" \
     description="TCP echo server from Asio samples project" \

--- a/docker/ma_echo_server/distroless/Dockerfile
+++ b/docker/ma_echo_server/distroless/Dockerfile
@@ -5,7 +5,9 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM ubuntu:20.04 AS build
+FROM debian:11 AS build
+
+ENV TZ="Europe/Moscow"
 
 RUN apt-get update && \
     apt-get install -y --no-install-suggests --no-install-recommends \
@@ -14,30 +16,19 @@ RUN apt-get update && \
       git \
       g++ \
       make \
-      libstdc++-9-dev && \
+      libboost-all-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CMAKE_HOME="/opt/cmake"
 
-ARG CMAKE_VERSION="3.20.1"
+ARG CMAKE_VERSION="3.21.3"
 
 RUN mkdir -p "${CMAKE_HOME}" && \
     cmake_url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" && \
     echo "Downloading CMake ${CMAKE_VERSION} from ${cmake_url} to ${CMAKE_HOME}" && \
     curl -jksSL "${cmake_url}" | tar -xzf - -C "${CMAKE_HOME}" --strip-components 1
 
-ENV PATH="${CMAKE_HOME}/bin:${PATH}" \
-    BOOST_HOME="/usr/lib/boost"
-
-ARG BOOST_VERSION="1.76.0"
-ARG BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost"
-
-RUN mkdir -p "${BOOST_HOME}" && \
-    boost_archive_url="${BOOST_URL}/${BOOST_VERSION}/boost-${BOOST_VERSION}-x64-gcc$(gcc -dumpversion | sed -r 's/^([[:digit:]]+)(\..*)?$/\1/;t;d').tar.gz" && \
-    echo "Downloading Boost from ${boost_archive_url} to ${BOOST_HOME}" && \
-    curl --connect-timeout 300 --max-time 1800 --retry 10 --retry-delay 10 \
-      -jksSL "${boost_archive_url}" \
-      | tar -xz -C "${BOOST_HOME}" --strip-components 1
+ENV PATH="${CMAKE_HOME}/bin:${PATH}"
 
 ARG MA_REVISION="master"
 
@@ -49,9 +40,6 @@ RUN source_dir="$(mktemp -d)" && \
       -D CMAKE_SKIP_BUILD_RPATH=ON \
       -D CMAKE_BUILD_TYPE=RELEASE \
       -D Boost_USE_STATIC_LIBS=ON \
-      -D Boost_NO_SYSTEM_PATHS=ON \
-      -D BOOST_INCLUDEDIR="${BOOST_HOME}/include" \
-      -D BOOST_LIBRARYDIR="${BOOST_HOME}/lib" \
       -D MA_TESTS=OFF \
       -D MA_QT=OFF \
       -S "${source_dir}" \
@@ -63,7 +51,7 @@ RUN source_dir="$(mktemp -d)" && \
     rm -rf "${build_dir}" && \
     rm -rf "${source_dir}"
 
-FROM gcr.io/distroless/cc-debian10
+FROM gcr.io/distroless/cc-debian11
 
 LABEL name="abrarov/tcp-echo" \
     description="TCP echo server from Asio samples project" \

--- a/docker/ma_echo_server/nanoserver/Dockerfile
+++ b/docker/ma_echo_server/nanoserver/Dockerfile
@@ -7,12 +7,18 @@
 
 FROM abrarov/msvc-2019:2.12.1 AS build
 
-ENV BOOST_VERSION="1.76.0" \
-    BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost" \
-    SOURCE_DIR="C:\asio_samples" \
-    BUILD_DIR="C:\build" \
-    DEPENDENCIES_DIR="C:\dependencies" \
-    DOWNLOADS_DIR="C:\downloads"
+ENV DOWNLOADS_DIR="C:\download" \
+    BOOST_DIR="C:\dependencies\boost"
+
+ADD ["install", "C:/install/"]
+
+ARG BOOST_VERSION="1.77.0"
+ARG BOOST_URL="https://boostorg.jfrog.io/ui/api/v1/download?repoKey=main&path="
+
+RUN powershell -ExecutionPolicy Bypass -File "C:\install\install.ps1"
+
+ENV SOURCE_DIR="C:\asio_samples" \
+    BUILD_DIR="C:\build"
 
 ADD ["app", "C:/app/"]
 

--- a/docker/ma_echo_server/nanoserver/app/build.ps1
+++ b/docker/ma_echo_server/nanoserver/app/build.ps1
@@ -8,54 +8,6 @@
 # Stop immediately if any error happens
 $ErrorActionPreference = "Stop"
 
-# Enable all versions of TLS
-[System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11","Tls","Ssl3")
-
-$boost_version_suffix = "-${env:BOOST_VERSION}"
-$boost_platform_suffix = "-x64"
-$boost_toolchain_suffix = ""
-switch (${env:MSVS_VERSION}) {
-  "16" {
-    $boost_toolchain_suffix = "-vs2019"
-  }
-  "15" {
-    $boost_toolchain_suffix = "-vs2017"
-  }
-  "14" {
-    $boost_toolchain_suffix = "-vs2015"
-  }
-  default {
-    throw "Unsupported MSVC version for Boost: ${env:MSVS_VERSION}"
-  }
-}
-$boost_install_folder = "${env:DEPENDENCIES_DIR}\boost${boost_version_suffix}${boost_platform_suffix}${boost_toolchain_suffix}"
-if (!(Test-Path -Path "${boost_install_folder}")) {
-  $boost_archive_name = "boost${boost_version_suffix}${boost_platform_suffix}${boost_toolchain_suffix}.7z"
-  $boost_archive_file = "${env:DOWNLOADS_DIR}\${boost_archive_name}"
-  if (!(Test-Path -Path "${boost_archive_file}")) {
-    $boost_download_url = "${env:BOOST_URL}/${env:BOOST_VERSION}/${boost_archive_name}"
-    if (!(Test-Path -Path "${env:DOWNLOADS_DIR}")) {
-      New-Item -Path "${env:DOWNLOADS_DIR}" -ItemType "directory" | out-null
-    }
-    Write-Host "Downloading Boost from ${boost_download_url} to ${boost_archive_file}"
-    (New-Object System.Net.WebClient).DownloadFile("${boost_download_url}", "${boost_archive_file}")
-    Write-Host "Downloading of Boost completed successfully"
-  }
-  Write-Host "Extracting Boost from ${boost_archive_file} to ${env:DEPENDENCIES_DIR}"
-  if (!(Test-Path -Path "${env:DEPENDENCIES_DIR}")) {
-    New-Item -Path "${env:DEPENDENCIES_DIR}" -ItemType "directory" | out-null
-  }
-  & "${env:SEVEN_ZIP_HOME}\7z.exe" x "${boost_archive_file}" -o"${env:DEPENDENCIES_DIR}" -aoa -y -bd | out-null
-  if (${LastExitCode} -ne 0) {
-    throw "Extracting of Boost failed with exit code ${LastExitCode}"
-  }
-  Write-Host "Extracting of Boost completed successfully"
-}
-Write-Host "Boost ${env:BOOST_VERSION} is located at ${boost_install_folder}"
-$boost_include_folder_version_suffix = "-${env:BOOST_VERSION}" -replace "([\d]+)\.([\d]+)(\.[\d]+)*", '$1_$2'
-$env:BOOST_INCLUDE_DIR = "${boost_install_folder}\include\boost${boost_include_folder_version_suffix}"
-$env:BOOST_LIBRARY_DIR = "${boost_install_folder}\lib"
-
 switch (${env:MSVS_VERSION}) {
   "16" {
     $env:MSVS_INSTALL_DIR = &vswhere --% -latest -products Microsoft.VisualStudio.Product.Community -version [16.0,17.0) -requires Microsoft.VisualStudio.Workload.NativeDesktop -property installationPath

--- a/docker/ma_echo_server/nanoserver/install/install.ps1
+++ b/docker/ma_echo_server/nanoserver/install/install.ps1
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2021 Marat Abrarov (abrarov@gmail.com)
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# Stop immediately if any error happens
+$ErrorActionPreference = "Stop"
+
+# Enable all versions of TLS
+[System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11","Tls","Ssl3")
+
+$boost_version_suffix = "${env:BOOST_VERSION}" -replace "\.", '_'
+$boost_platform_suffix = "-64"
+$boost_toolchain_suffix = "-msvc"
+switch (${env:MSVS_VERSION}) {
+  "16" {
+    $boost_toolchain_suffix = "${boost_toolchain_suffix}-14.2"
+  }
+  "15" {
+    $boost_toolchain_suffix = "${boost_toolchain_suffix}-14.1"
+  }
+  "14" {
+    $boost_toolchain_suffix = "${boost_toolchain_suffix}-14.0"
+  }
+  default {
+    throw "Unsupported MSVC version for Boost: ${env:MSVS_VERSION}"
+  }
+}
+$boost_installer_file_name = "boost_${boost_version_suffix}${boost_toolchain_suffix}${boost_platform_suffix}.exe"
+$boost_installer_file = "${env:DOWNLOADS_DIR}\${boost_installer_file_name}"
+
+Add-Type -AssemblyName System.Web
+$boost_download_url = "${env:BOOST_URL}" + [System.Web.HttpUtility]::UrlEncode([System.Web.HttpUtility]::UrlEncode("release/${env:BOOST_VERSION}/binaries/${boost_installer_file_name}"))
+if (-not (Test-Path -Path "${env:DOWNLOADS_DIR}")) {
+  New-Item -Path "${env:DOWNLOADS_DIR}" -ItemType "directory" | out-null
+}
+Write-Host "Downloading Boost from ${boost_download_url} to ${boost_installer_file}"
+(New-Object System.Net.WebClient).DownloadFile("${boost_download_url}", "${boost_installer_file}")
+
+$boost_parent_dir = Split-Path "${env:BOOST_DIR}" -Parent
+if (-not (Test-Path -Path "${boost_parent_dir}")) {
+  Write-Host "Creating ${boost_parent_dir} directory"
+  New-Item -Path "${boost_parent_dir}" -ItemType "directory" | out-null
+}
+Write-Host "Installing Boost from ${boost_installer_file} to ${env:BOOST_DIR}"
+$p = Start-Process -FilePath "${boost_installer_file}" `
+  -ArgumentList ("/SP-", "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/NOICONS", "/ALLUSERS", "/DIR=""${env:BOOST_DIR}""") `
+  -Wait -PassThru
+if (${p}.ExitCode -ne 0) {
+  throw "Failed to install Boost"
+}
+
+$env:BOOST_INCLUDE_DIR = "${env:BOOST_DIR}"
+$env:BOOST_LIBRARY_DIR = "${env:BOOST_DIR}\lib64${boost_toolchain_suffix}"
+
+[Environment]::SetEnvironmentVariable("BOOST_INCLUDE_DIR", "${env:BOOST_INCLUDE_DIR}", [System.EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("BOOST_LIBRARY_DIR", "${env:BOOST_LIBRARY_DIR}", [System.EnvironmentVariableTarget]::Machine)

--- a/docker/ma_echo_server/static/Dockerfile
+++ b/docker/ma_echo_server/static/Dockerfile
@@ -5,30 +5,62 @@
 # file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-FROM alpine:3.13.5 AS build
+FROM alpine:3.13.6 AS build
 
 RUN apk add --no-cache \
-      libstdc++ \
-      linux-headers \
+      bash \
+      ca-certificates \
+      curl \
+      tar \
+      gzip \
+      git \
       g++ \
       make \
       cmake \
-      git \
-      curl \
-      tar \
-      gzip
+      libstdc++ \
+      linux-headers \
+      icu-dev \
+      python2-dev \
+      libzip-dev \
+      libbz2
 
-ENV BOOST_HOME="/usr/lib/boost"
+ARG BOOST_VERSION="1.77.0"
+ARG BOOST_RELEASE_URL="https://boostorg.jfrog.io/artifactory/main/release"
+ARG BOOST_BUILD_OPTIONS="--without-mpi --without-graph_parallel"
 
-ARG BOOST_VERSION="1.76.0"
-ARG BOOST_URL="https://dl.bintray.com/mabrarov/generic/boost"
+ENV BOOST_INSTALL_DIR="/opt/boost"
 
-RUN mkdir -p "${BOOST_HOME}" && \
-    boost_archive_url="${BOOST_URL}/${BOOST_VERSION}/boost-${BOOST_VERSION}-x64-gcc10-musl-static-runtime.tar.gz" && \
-    echo "Downloading Boost from ${boost_archive_url} into ${BOOST_HOME}" && \
-    curl --connect-timeout 300 --max-time 1800 --retry 10 --retry-delay 10 \
-      -jksSL "${boost_archive_url}" \
-      | tar -xz -C "${BOOST_HOME}" --strip-components 1
+RUN mkdir -p "${BOOST_INSTALL_DIR}" && \
+    boost_build_dir="$(mktemp -d)" && \
+    boost_download_url="${BOOST_RELEASE_URL}/${BOOST_VERSION}/source/boost_$(echo "${BOOST_VERSION}" | sed -r 's/\./_/g').tar.gz" && \
+    echo "Downloading Boost C++ Libraries (source code archive) from ${boost_download_url} into ${boost_build_dir} directory" && \
+    curl -jksSL "${boost_download_url}" | tar -xzf - -C "${boost_build_dir}" --strip-components 1 && \
+    b2_bin="${boost_build_dir}/b2" && \
+    b2_toolset="gcc" && \
+    boost_bootstrap="${boost_build_dir}/bootstrap.sh" && \
+    current_dir="$(pwd)" && \
+    cd "${boost_build_dir}" && \
+    echo "Building Boost.Build engine" && \
+    "${boost_bootstrap}" && \
+    boost_linkage="static" && \
+    boost_runtime_linkage="static" && \
+    echo "Building Boost C++ Libraries with these parameters:" && \
+    echo "B2_BIN               : ${b2_bin}" && \
+    echo "B2_TOOLSET           : ${b2_toolset}" && \
+    echo "BOOST_INSTALL_DIR    : ${BOOST_INSTALL_DIR}" && \
+    echo "BOOST_LINKAGE        : ${boost_linkage}" && \
+    echo "BOOST_RUNTIME_LINKAGE: ${boost_runtime_linkage}" && \
+    echo "BOOST_BUILD_OPTIONS  : ${BOOST_BUILD_OPTIONS}" && \
+    "${b2_bin}" \
+      --toolset="${b2_toolset}" \
+      link="${boost_linkage}" \
+      runtime-link="${boost_runtime_linkage}" \
+      install \
+      --prefix="${BOOST_INSTALL_DIR}" \
+      --layout=system \
+      ${BOOST_BUILD_OPTIONS} && \
+    cd "${current_dir}" && \
+    rm -rf "${boost_build_dir}"
 
 ARG MA_REVISION="master"
 
@@ -43,8 +75,8 @@ RUN source_dir="$(mktemp -d)" && \
       -D CMAKE_USER_MAKE_RULES_OVERRIDE_CXX="${source_dir}/cmake/static_cxx_runtime_overrides.cmake" \
       -D Boost_USE_STATIC_LIBS=ON \
       -D Boost_NO_SYSTEM_PATHS=ON \
-      -D BOOST_INCLUDEDIR="${BOOST_HOME}/include" \
-      -D BOOST_LIBRARYDIR="${BOOST_HOME}/lib" \
+      -D BOOST_INCLUDEDIR="${BOOST_INSTALL_DIR}/include" \
+      -D BOOST_LIBRARYDIR="${BOOST_INSTALL_DIR}/lib" \
       -D MA_TESTS=OFF \
       -D MA_QT=OFF \
       -S "${source_dir}" \
@@ -56,7 +88,7 @@ RUN source_dir="$(mktemp -d)" && \
     rm -rf "${build_dir}" && \
     rm -rf "${source_dir}"
 
-FROM scratch
+FROM gcr.io/distroless/static
 
 LABEL name="abrarov/tcp-echo" \
     description="TCP echo server from Asio samples project" \


### PR DESCRIPTION
* Switched Distroless-based docker image with ma_echo_server example to the latest version of base image (which is based on Debian 11).
* Updated builder images to the latest version of base OS and CMake.
* Fixed docker image with statically linked ma_echo_server example after Bintray decommission.
* Fixed docker image with ma_echo_server example for Windows Containers after decommission of Bintray.






