### PR TITLE
K8s deployment of ma_echo_server

### DIFF
--- a/kubernetes/tcp-echo/templates/deployment.yaml
+++ b/kubernetes/tcp-echo/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
+        {{- include "app.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Fixed labels for pods created using Helm chart for ma_echo_server_example.