### PR TITLE
Fix for handler_storage_service::shutdown

### DIFF
--- a/libs/ma_handler_storage/include/ma/handler_storage_service.hpp
+++ b/libs/ma_handler_storage/include/ma/handler_storage_service.hpp
@@ -127,7 +127,7 @@ private:
   // Double-linked intrusive list of active implementations.
   impl_base_list impl_list_;
   // Shutdown state flag.
-  bool shutdown_;
+  volatile bool shutdown_;
 }; // class handler_storage_service
 
 inline bad_handler_call::bad_handler_call()


### PR DESCRIPTION
`volatile` modifier for the handler_storage_service shutdown state.