### PR TITLE
tcp-echo Helm chart refactoring

### DIFF
--- a/kubernetes/tcp-echo/templates/_helpers.tpl
+++ b/kubernetes/tcp-echo/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "app.name" -}}
+{{- define "tcp-echo.name" -}}
 {{- .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "app.fullname" -}}
+{{- define "tcp-echo.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,90 +26,90 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "app.chart" -}}
+{{- define "tcp-echo.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "app.labels" -}}
-helm.sh/chart: {{ include "app.chart" . | quote }}
-{{ include "app.selectorLabels" . }}
+{{- define "tcp-echo.labels" -}}
+helm.sh/chart: {{ include "tcp-echo.chart" . | quote }}
+{{ include "tcp-echo.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app: {{ include "app.name" . | quote }}
+app: {{ include "tcp-echo.name" . | quote }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "app.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "app.name" . | quote }}
+{{- define "tcp-echo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tcp-echo.name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end }}
 
 {{/*
 Name of deployment.
 */}}
-{{- define "app.deploymentName" -}}
-{{ include "app.fullname" . }}
+{{- define "tcp-echo.deploymentName" -}}
+{{ include "tcp-echo.fullname" . }}
 {{- end }}
 
 {{/*
 Name of service.
 */}}
-{{- define "app.serviceName" -}}
-{{ include "app.fullname" . }}
+{{- define "tcp-echo.serviceName" -}}
+{{ include "tcp-echo.fullname" . }}
 {{- end }}
 
 {{/*
 Name of container port.
 */}}
-{{- define "app.containerPortName" -}}
+{{- define "tcp-echo.containerPortName" -}}
 tcp-echo
 {{- end }}
 
 {{/*
 Name of service port.
 */}}
-{{- define "app.servicePortName" -}}
+{{- define "tcp-echo.servicePortName" -}}
 tcp-echo
 {{- end }}
 
 {{/*
 Container image tag.
 */}}
-{{- define "app.containerImageTag" -}}
+{{- define "tcp-echo.containerImageTag" -}}
 {{ .Values.container.image.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{/*
 Container image full name.
 */}}
-{{- define "app.containerImageFullName" -}}
-{{ printf "%s:%s" .Values.container.image.repository (include "app.containerImageTag" . ) }}
+{{- define "tcp-echo.containerImageFullName" -}}
+{{ printf "%s:%s" .Values.container.image.repository (include "tcp-echo.containerImageTag" . ) }}
 {{- end }}
 
 {{/*
 Termination grace period.
 */}}
-{{- define "app.terminationGracePeriod" -}}
+{{- define "tcp-echo.terminationGracePeriod" -}}
 {{ add (.Values.tcpEcho.stopTimeout | default 60) 5 }}
 {{- end }}
 
 {{/*
 Name of test pod.
 */}}
-{{- define "app.testPodName" -}}
-{{ include "app.fullname" . }}-test
+{{- define "tcp-echo.testPodName" -}}
+{{ include "tcp-echo.fullname" . }}-test
 {{- end }}
 
 {{/*
 Test container image full name.
 */}}
-{{- define "test.containerImageFullName" -}}
+{{- define "tcp-echo.testContainerImageFullName" -}}
 {{ printf "%s:%s" .Values.test.image.repository (.Values.test.image.tag | default "latest") }}
 {{- end }}

--- a/kubernetes/tcp-echo/templates/deployment.yaml
+++ b/kubernetes/tcp-echo/templates/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
-  name: {{ include "app.deploymentName" . | quote }}
+  name: {{ include "tcp-echo.deploymentName" . | quote }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "tcp-echo.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "app.selectorLabels" . | nindent 6 }}
+      {{- include "tcp-echo.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "app.labels" . | nindent 8 }}
+        {{- include "tcp-echo.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Values.container.name | quote }}
-          image: {{ include "app.containerImageFullName" . | quote }}
+          image: {{ include "tcp-echo.containerImageFullName" . | quote }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           args:
             - "--port"
@@ -36,16 +36,16 @@ spec:
             - "--buffer"
             - {{ .Values.tcpEcho.bufferSize | default 4096 | quote }}
           ports:
-            - name: {{ include "app.containerPortName" . | quote }}
+            - name: {{ include "tcp-echo.containerPortName" . | quote }}
               containerPort: {{ .Values.tcpEcho.port }}
           livenessProbe:
             tcpSocket:
-              port: {{ include "app.containerPortName" . | quote }}
+              port: {{ include "tcp-echo.containerPortName" . | quote }}
             initialDelaySeconds: {{ .Values.container.liveness.initialDelay }}
           readinessProbe:
             tcpSocket:
-              port: {{ include "app.containerPortName" . | quote }}
+              port: {{ include "tcp-echo.containerPortName" . | quote }}
             initialDelaySeconds: {{ .Values.container.readiness.initialDelay }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-      terminationGracePeriodSeconds: {{ include "app.terminationGracePeriod" . }}
+      terminationGracePeriodSeconds: {{ include "tcp-echo.terminationGracePeriod" . }}

--- a/kubernetes/tcp-echo/templates/service.yaml
+++ b/kubernetes/tcp-echo/templates/service.yaml
@@ -1,15 +1,15 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  name: {{ include "app.serviceName" . | quote }}
+  name: {{ include "tcp-echo.serviceName" . | quote }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "tcp-echo.labels" . | nindent 4 }}
 spec:
   type: "NodePort"
   ports:
-    - name: {{ include "app.servicePortName" . | quote }}
+    - name: {{ include "tcp-echo.servicePortName" . | quote }}
       port: {{ .Values.service.port }}
-      targetPort: {{ include "app.containerPortName" . | quote }}
+      targetPort: {{ include "tcp-echo.containerPortName" . | quote }}
       nodePort: {{ .Values.service.nodePort }}
   selector:
-    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- include "tcp-echo.selectorLabels" . | nindent 4 }}

--- a/kubernetes/tcp-echo/templates/tests/test.yaml
+++ b/kubernetes/tcp-echo/templates/tests/test.yaml
@@ -1,9 +1,9 @@
 apiVersion: "v1"
 kind: "Pod"
 metadata:
-  name: {{ include "app.testPodName" . | quote }}
+  name: {{ include "tcp-echo.testPodName" . | quote }}
   labels:
-    {{- include "app.labels" . | nindent 4 }}
+    {{- include "tcp-echo.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "test"
 spec:
@@ -13,11 +13,11 @@ spec:
   {{- end }}
   containers:
     - name: {{ .Values.test.name | quote }}
-      image: {{ include "test.containerImageFullName" . | quote }}
+      image: {{ include "tcp-echo.testContainerImageFullName" . | quote }}
       imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
       command:
         - "sh"
       args:
         - "-c"
-        - {{ (printf "message='%s' && echo \"${message}\" | timeout 1s nc '%s' %d || true | grep -m 1 -F -- \"${message}\" >/dev/null" (.Values.test.message | replace "'" "'\"'\"'") (include "app.serviceName" . | replace "'" "'\"'\"'") (int .Values.service.port)) | quote }}
+        - {{ (printf "message='%s' && echo \"${message}\" | timeout 1s nc '%s' %d || true | grep -m 1 -F -- \"${message}\" >/dev/null" (.Values.test.message | replace "'" "'\"'\"'") (include "tcp-echo.serviceName" . | replace "'" "'\"'\"'") (int .Values.service.port)) | quote }}
   restartPolicy: Never


### PR DESCRIPTION
Renamed defined templates of tcp-echo Helm chart (used for deployment of ma_echo_server example) to use name of the chart as prefix, because Helm defined templates are global.